### PR TITLE
fix(ci): use github.token for PR creation and fix changelog regex truncation

### DIFF
--- a/.github/prepare_changelog.py
+++ b/.github/prepare_changelog.py
@@ -33,10 +33,9 @@ def extract_unreleased_content(content):
     # Extract each subsection
     sections = {}
     for section in STANDARD_SECTIONS:
-        # Match section header, then capture content until next section/heading
-        # Use negative lookahead to stop before next ### or ##
-        pattern = rf"### {section}\s*\n((?:(?!###|##).)*)"
-        match = re.search(pattern, unreleased_text, re.DOTALL)
+        # Match section header, capture content until next heading at line start
+        pattern = rf"^### {section}\s*\n(.*?)(?=^### |^## |\Z)"
+        match = re.search(pattern, unreleased_text, re.MULTILINE | re.DOTALL)
         if match:
             section_content = match.group(1).strip()
             # Only keep if it has actual bullet points (lines starting with -)

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -220,7 +220,7 @@ jobs:
       - name: Create draft PR to main
         id: pr
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ github.token }}
           VERSION: ${{ needs.validate.outputs.version }}
           RELEASE_BRANCH: ${{ needs.validate.outputs.release_branch }}
           CHANGELOG_CONTENT: ${{ steps.changelog.outputs.changelog }}


### PR DESCRIPTION
## Summary

- Use `github.token` instead of the App token for the "Create draft PR to main" step in `prepare-release.yml`, fixing `Resource not accessible by integration (createPullRequest)` error
- Fix `extract_unreleased_content()` regex in `prepare_changelog.py` that matched `##`/`###` at any character position, silently truncating changelog entries containing inline heading markers (e.g. `` `##` ``)

## Test plan

- [x] All 19 existing `test_prepare_changelog.py` tests pass
- [x] Manual verification: `prepare_changelog.py prepare` + `extract-notes` now preserves all 6 Fixed entries (was truncated to 1)
- [ ] Re-run Prepare Release workflow with version `0.2.0` after merge (stale `release/0.2.0` branch already deleted)

Refs: #18