### PR TITLE
fix(ci): use app token for PR creation in prepare-release

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -220,7 +220,7 @@ jobs:
       - name: Create draft PR to main
         id: pr
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           VERSION: ${{ needs.validate.outputs.version }}
           RELEASE_BRANCH: ${{ needs.validate.outputs.release_branch }}
           CHANGELOG_CONTENT: ${{ steps.changelog.outputs.changelog }}


### PR DESCRIPTION
## Summary

- The "Create draft PR to main" step in `prepare-release.yml` was using `github.token` (the default `GITHUB_TOKEN`), which lacks permission to create pull requests when the repo setting is disabled. Switched to the GitHub App token (`steps.app-token.outputs.token`) already generated earlier in the same job.

## Test plan

- [ ] Re-run the Prepare Release workflow and confirm the draft PR is created successfully

Refs: #18 