### PR TITLE
chore(ci): clarify weekly CodeQL scheduled scan purpose

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,7 +5,7 @@
 # Triggers:
 #   - Pull requests to dev, release/**, and main
 #   - Pushes to main (post-merge analysis)
-#   - Weekly schedule (catch newly disclosed patterns)
+#   - Weekly schedule (re-run with updated CodeQL rules/engines even when repo code is unchanged)
 
 name: CodeQL
 


### PR DESCRIPTION
## Summary
- Clarifies the weekly CodeQL schedule comment in `.github/workflows/codeql.yml`
- Makes explicit that the scheduled run re-scans with updated CodeQL rules/engines even when repository code has not changed
- Removes ambiguity noted in PR #22 review discussion

## Test plan
- [x] Confirm only workflow comments changed (no runtime workflow logic changes)
- [x] Validate YAML remains syntactically valid
- [x] Verify wording addresses reviewer question about schedule purpose

Refs: #29