### PR TITLE
fix: allow reusable workflow permissions in release integration test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -301,6 +301,10 @@ jobs:
     name: Integration Test (Finalized)
     needs: [validate, finalize]
     uses: ./.github/workflows/integration-test.yml
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
     with:
       ref: ${{ needs.finalize.outputs.finalize_sha }}
 


### PR DESCRIPTION
## Description
Fix release workflow validation failure in dry-run mode by allowing the reusable integration test workflow to request required read scopes.

## Type of Change
- [x] `fix` -- Bug fix
- [ ] `ci` -- CI/CD pipeline changes

### Modifiers
- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made
- Added job-level permissions to `integration-test` in `.github/workflows/release.yml`
- Granted only minimum required scopes: `contents: read`, `issues: read`, `pull-requests: read`

## Changelog Entry
No changelog needed (workflow permission fix only).

## Testing
- [x] Tests pass locally (`npm test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details
- Verified workflow schema error cause against reusable workflow requested permissions.
- Confirmed caller now explicitly allows required read scopes.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes
Scoped permissions are set only on the reusable workflow caller job to preserve least privilege.

Refs: #31