### PR TITLE
fix: sync workflow safe defaults and configurable inputs for post-release

### DIFF
--- a/.github/workflows/sync-issues.yml
+++ b/.github/workflows/sync-issues.yml
@@ -22,6 +22,16 @@ on:  # yamllint disable-line rule:truthy
         required: false
         default: 'dev'
         type: string
+      output-dir:
+        description: 'Directory to write synced issue/PR files to.'
+        required: false
+        default: 'docs'
+        type: string
+      commit-msg:
+        description: 'Commit message for the sync commit.'
+        required: false
+        default: 'chore: sync issues and PRs'
+        type: string
 
 permissions: {}  # restrict default; job declares its own
 
@@ -50,7 +60,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
-          ref: ${{ github.event.inputs.target-branch }}
+          ref: ${{ github.event.inputs.target-branch || 'dev' }}
           persist-credentials: false
 
       - name: Restore sync state (last synced timestamp)
@@ -66,7 +76,7 @@ jobs:
         if: always()
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           echo "Attempting to delete old cache to prevent save collisions..."
           # Wait a moment to ensure any previous cache saves have completed
@@ -83,17 +93,16 @@ jobs:
 
       - name: Sync Issues and PRs
         id: sync
-        uses: ./
+        uses: vig-os/sync-issues-action@3a9d87584de371ecfd0c044336f494bf8dc1cc0a  # v0.2.2
         with:
           app-id: ${{ secrets.APP_SYNC_ISSUES_ID }}
           app-private-key: ${{ secrets.APP_SYNC_ISSUES_PRIVATE_KEY }}
-          output-dir: 'docs'
+          output-dir: ${{ github.event.inputs.output-dir || 'docs' }}
           sync-issues: 'true'
           sync-prs: 'true'
           include-closed: 'true'
           state-file: '.sync-state/last-sync.txt'
-          force-update: ${{ github.event.inputs.force-update }}
-          updated-since: ${{ github.event.inputs.force-update == 'true' && '1970-01-01T00:00:00Z' || '' }}
+          updated-since: ${{ (github.event.inputs.force-update == 'true' && '1970-01-01T00:00:00Z') || '' }}
 
       - name: Commit and push changes via API
         id: commit
@@ -103,8 +112,8 @@ jobs:
           # Use App token so push can bypass branch protection when App is in bypass list
           GH_TOKEN: ${{ steps.generate-token.outputs.token || github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-          TARGET_BRANCH: refs/heads/${{ github.event.inputs.target-branch }}
-          COMMIT_MESSAGE: "chore: sync issues and PRs"
+          TARGET_BRANCH: refs/heads/${{ github.event.inputs.target-branch || 'dev' }}
+          COMMIT_MESSAGE: "${{ github.event.inputs.commit-msg || 'chore: sync issues and PRs' }}"
           FILE_PATHS: ${{ steps.sync.outputs.modified-files }}
 
       - name: Save sync state

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Sync workflow: configurable output-dir and commit-msg** ([#52](https://github.com/vig-os/sync-issues-action/issues/52))
+  - New workflow inputs `output-dir` (default `docs`) and `commit-msg` (default `chore: sync issues and PRs`) for dispatch runs
+
 ### Changed
+
+- **Sync workflow: safe defaults and pinned action ref** ([#52](https://github.com/vig-os/sync-issues-action/issues/52))
+  - Checkout and commit step use `target-branch || 'dev'` and `commit-msg` input so defaults apply when inputs are omitted
+  - Workflow uses pinned action ref (v0.2.2) instead of local checkout
+  - Cache delete step uses `github.token`; `force-update` no longer passed to action (only `updated-since` used)
 
 ### Deprecated
 


### PR DESCRIPTION
## Description

Post-release hardening for the sync-issues workflow: add configurable `output-dir` and `commit-msg` inputs, use safe defaults (`target-branch || 'dev'`, commit message input), pin the workflow to action ref v0.2.2 instead of local checkout, and simplify the cache-delete step (use `github.token`; stop passing `force-update` to the action, use only `updated-since` when applicable).

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- **`.github/workflows/sync-issues.yml`**
  - New workflow inputs: `output-dir` (default `docs`), `commit-msg` (default `chore: sync issues and PRs`)
  - Checkout and commit step use `target-branch || 'dev'` and `commit-msg` so defaults apply when inputs are omitted
  - Workflow uses pinned action ref (v0.2.2) instead of local checkout
  - Cache delete step uses `github.token`; `force-update` no longer passed to action (only `updated-since` used when provided)
- **`CHANGELOG.md`**
  - Unreleased: Added (configurable output-dir and commit-msg), Changed (safe defaults and pinned action ref)

## Changelog Entry

### Added

- **Sync workflow: configurable output-dir and commit-msg** ([#52](https://github.com/vig-os/sync-issues-action/issues/52))
  - New workflow inputs `output-dir` (default `docs`) and `commit-msg` (default `chore: sync issues and PRs`) for dispatch runs

### Changed

- **Sync workflow: safe defaults and pinned action ref** ([#52](https://github.com/vig-os/sync-issues-action/issues/52))
  - Checkout and commit step use `target-branch || 'dev'` and `commit-msg` input so defaults apply when inputs are omitted
  - Workflow uses pinned action ref (v0.2.2) instead of local checkout
  - Cache delete step uses `github.token`; `force-update` no longer passed to action (only `updated-since` used)

## Testing

- [x] Tests pass locally (`npm run test:all`)

N/A

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

N/A

Refs: #52
