### PR TITLE
fix(ci): split sync workflow auth between commit and release apps

### DIFF
--- a/.github/workflows/sync-issues.yml
+++ b/.github/workflows/sync-issues.yml
@@ -87,7 +87,7 @@ jobs:
         with:
           app-id: ${{ secrets.COMMIT_APP_ID }}
           app-private-key: ${{ secrets.COMMIT_APP_PRIVATE_KEY }}
-          output-dir: ${{ github.event.inputs.output-dir || 'docs' }}
+          output-dir: 'docs'
           sync-issues: 'true'
           sync-prs: 'true'
           include-closed: 'true'

--- a/.github/workflows/sync-issues.yml
+++ b/.github/workflows/sync-issues.yml
@@ -44,8 +44,8 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf  # v2
         with:
-          app-id: ${{ secrets.APP_SYNC_ISSUES_ID }}
-          private-key: ${{ secrets.APP_SYNC_ISSUES_PRIVATE_KEY }}
+          app-id: ${{ secrets.COMMIT_APP_ID }}
+          private-key: ${{ secrets.COMMIT_APP_PRIVATE_KEY }}
 
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
@@ -85,9 +85,9 @@ jobs:
         id: sync
         uses: ./
         with:
-          app-id: ${{ secrets.APP_SYNC_ISSUES_ID }}
-          app-private-key: ${{ secrets.APP_SYNC_ISSUES_PRIVATE_KEY }}
-          output-dir: 'docs'
+          app-id: ${{ secrets.COMMIT_APP_ID }}
+          app-private-key: ${{ secrets.COMMIT_APP_PRIVATE_KEY }}
+          output-dir: ${{ github.event.inputs.output-dir || 'docs' }}
           sync-issues: 'true'
           sync-prs: 'true'
           include-closed: 'true'

--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -12,8 +12,9 @@
 #         - open PR (auto-mergeable, or labelled "merge-conflict" with
 #           resolution instructions when conflicts exist)
 #
-# Auth: GitHub App token (COMMIT_APP_ID / COMMIT_APP_PRIVATE_KEY), a dedicated
-# secret set for git/API operations requiring app identity and signing.
+# Auth: Two GitHub App tokens:
+#   - COMMIT_APP_* for git/ref operations (least-privilege commit identity)
+#   - RELEASE_APP_* for PR/label operations that require pull-request scopes
 #
 # Triggers: push to main · workflow_dispatch
 #
@@ -94,19 +95,26 @@ jobs:
       issues: write
 
     steps:
-      - name: Generate GitHub App Token
-        id: app-token
+      - name: Generate Commit App Token
+        id: commit-app-token
         uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf  # v2
         with:
           app-id: ${{ secrets.COMMIT_APP_ID }}
           private-key: ${{ secrets.COMMIT_APP_PRIVATE_KEY }}
+
+      - name: Generate Release App Token
+        id: release-app-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf  # v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Checkout dev
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           ref: dev
           fetch-depth: 0
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.commit-app-token.outputs.token }}
 
       - name: Re-check if dev is still behind main
         id: recheck
@@ -147,7 +155,7 @@ jobs:
         if: steps.recheck.outputs.up_to_date != 'true'
         id: existing-pr
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
         run: |
           set -euo pipefail
           OPEN=$(gh pr list --base dev --state open --limit 200 \
@@ -161,7 +169,7 @@ jobs:
       - name: Clean up stale sync branches
         if: steps.recheck.outputs.up_to_date != 'true'
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
         run: |
           set -euo pipefail
           REFS=$(gh api --paginate "repos/${{ github.repository }}/git/matching-refs/heads/chore/sync-main-to-dev-" \
@@ -178,7 +186,7 @@ jobs:
       - name: Create sync branch from main
         if: steps.existing-pr.outputs.count == '0'
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.commit-app-token.outputs.token }}
         run: |
           set -euo pipefail
           MAIN_SHA=$(git rev-parse origin/main)
@@ -190,7 +198,7 @@ jobs:
       - name: Create PR
         if: steps.existing-pr.outputs.count == '0'
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
           CONFLICT: ${{ steps.merge-check.outputs.conflict }}
           INPUT_TITLE: "${{ github.event.inputs['pr-title'] || 'chore: sync dev with main' }}"
           INPUT_BODY: "${{ github.event.inputs['pr-body'] || 'Syncs `dev` with `main` (sync-main-to-dev workflow).' }}"

--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -102,13 +102,6 @@ jobs:
           app-id: ${{ secrets.COMMIT_APP_ID }}
           private-key: ${{ secrets.COMMIT_APP_PRIVATE_KEY }}
 
-      - name: Generate Release App Token
-        id: release-app-token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf  # v2
-        with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-
       - name: Checkout dev
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
@@ -137,6 +130,14 @@ jobs:
             echo "up_to_date=false" >> "$GITHUB_OUTPUT"
             echo "Dev is still behind main by ${BEHIND} commit(s). Continuing."
           fi
+
+      - name: Generate Release App Token
+        if: steps.recheck.outputs.up_to_date != 'true'
+        id: release-app-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf  # v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Detect merge conflicts
         if: steps.recheck.outputs.up_to_date != 'true'

--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -169,13 +169,13 @@ jobs:
       - name: Clean up stale sync branches
         if: steps.recheck.outputs.up_to_date != 'true'
         env:
-          GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.commit-app-token.outputs.token }}
         run: |
           set -euo pipefail
           REFS=$(gh api --paginate "repos/${{ github.repository }}/git/matching-refs/heads/chore/sync-main-to-dev-" \
             --jq '.[].ref' | sed 's|refs/heads/||') || true
           for branch in ${REFS}; do
-            HAS_PR=$(gh pr list --base dev --head "${branch}" \
+            HAS_PR=$(GH_TOKEN="${{ steps.release-app-token.outputs.token }}" gh pr list --base dev --head "${branch}" \
               --state open --json number --jq 'length')
             if [ "${HAS_PR}" = "0" ]; then
               gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/${branch}" 2>/dev/null || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Remove `post-release.yml` workflow; add `sync-main-to-dev.yml` that opens a PR to sync `main` into `dev`, satisfying branch protection on both branches
   - Harden sync checks by failing clearly when `origin/main` or `origin/dev` is missing instead of silently treating branches as up to date
   - Fix `workflow_dispatch` hyphenated input access and conflict path robustness (`issues: write`, safer conflict label handling, clearer manual resolution commands)
-  - Reduce duplicate/no-op sync PR risk by re-checking ahead/behind state inside the `sync` job and tightening existing-sync-PR detection (search + explicit list limit); clarify `COMMIT_APP_*` as the dedicated git/API app secret set
+  - Reduce duplicate/no-op sync PR risk by re-checking ahead/behind state inside the `sync` job and tightening existing-sync-PR detection (search + explicit list limit)
+  - Split auth into explicit app tokens by responsibility: `COMMIT_APP_*` for checkout/ref operations and `RELEASE_APP_*` for PR/label operations requiring broader scopes
 
 ## [0.2.2] - 2026-02-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Reduce duplicate/no-op sync PR risk by re-checking ahead/behind state inside the `sync` job and tightening existing-sync-PR detection (search + explicit list limit)
   - Split auth into explicit app tokens by responsibility: `COMMIT_APP_*` for checkout/ref operations and `RELEASE_APP_*` for PR/label operations requiring broader scopes
   - Generate `RELEASE_APP_*` only after re-check confirms sync work remains, reducing unnecessary broader-scope token issuance
+- **Sync workflow uses commit-scoped app secrets and manual output target**
+  - Update `sync-issues.yml` to use `COMMIT_APP_ID`/`COMMIT_APP_PRIVATE_KEY` for both checkout token generation and action app auth inputs
+  - Respect `workflow_dispatch` `output-dir` input in the action call, with `'docs'` as the default fallback
 
 ## [0.2.2] - 2026-02-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Fix `workflow_dispatch` hyphenated input access and conflict path robustness (`issues: write`, safer conflict label handling, clearer manual resolution commands)
   - Reduce duplicate/no-op sync PR risk by re-checking ahead/behind state inside the `sync` job and tightening existing-sync-PR detection (search + explicit list limit)
   - Split auth into explicit app tokens by responsibility: `COMMIT_APP_*` for checkout/ref operations and `RELEASE_APP_*` for PR/label operations requiring broader scopes
+  - Generate `RELEASE_APP_*` only after re-check confirms sync work remains, reducing unnecessary broader-scope token issuance
 
 ## [0.2.2] - 2026-02-26
 


### PR DESCRIPTION
## Description

This PR finalizes the branch-protection-safe sync flow by tightening auth boundaries and workflow behavior across both sync workflows.

It separates GitHub App responsibilities (commit/ref operations vs PR/label operations), updates issue-sync auth to the commit app, and ensures manual sync output directory input is respected.

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [x] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `.github/workflows/sync-main-to-dev.yml`
  - Split auth into `COMMIT_APP_*` (checkout/git refs) and `RELEASE_APP_*` (PR/labels)
  - Keep stale sync-branch git-ref cleanup on commit-scoped token
  - Generate release token only when re-check confirms sync work is still needed
  - Keep conflict-path behavior and duplicate-PR guard intact
- `.github/workflows/sync-issues.yml`
  - Switch app auth secrets to `COMMIT_APP_ID` / `COMMIT_APP_PRIVATE_KEY`
  - Pass `workflow_dispatch` `output-dir` input through to the action with `docs` fallback
- `CHANGELOG.md`
  - Updated `Unreleased` notes for issue #52 to capture token split and sync-issues workflow updates

## Changelog Entry

### Changed

- **Post-release replaced by PR-based main-to-dev sync** ([#52](https://github.com/vig-os/sync-issues-action/issues/52))
  - Remove `post-release.yml` workflow; add `sync-main-to-dev.yml` that opens a PR to sync `main` into `dev`, satisfying branch protection on both branches
  - Harden sync checks by failing clearly when `origin/main` or `origin/dev` is missing instead of silently treating branches as up to date
  - Fix `workflow_dispatch` hyphenated input access and conflict path robustness (`issues: write`, safer conflict label handling, clearer manual resolution commands)
  - Reduce duplicate/no-op sync PR risk by re-checking ahead/behind state inside the `sync` job and tightening existing-sync-PR detection (search + explicit list limit)
  - Split auth into explicit app tokens by responsibility: `COMMIT_APP_*` for checkout/ref operations and `RELEASE_APP_*` for PR/label operations requiring broader scopes
  - Generate `RELEASE_APP_*` only after re-check confirms sync work remains, reducing unnecessary broader-scope token issuance
- **Sync workflow uses commit-scoped app secrets and manual output target**
  - Update `sync-issues.yml` to use `COMMIT_APP_ID`/`COMMIT_APP_PRIVATE_KEY` for both checkout token generation and action app auth inputs
  - Respect `workflow_dispatch` `output-dir` input in the action call, with `'docs'` as the default fallback

## Testing

- [x] Tests pass locally (`npm test`) — 95/95 passed
- [x] CHANGELOG validation passed (`prepare_changelog.py validate`)
- [x] Manual testing performed (conflict path and duplicate-PR guard)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have updated the documentation accordingly
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

Post-merge validation on `main` should still confirm no-op early exit and clean no-conflict PR creation paths.

Refs: #52
