### PR TITLE
fix: retry transient GitHub 5xx and skip failing items during sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- **Retry transient GitHub 5xx errors and skip failing items during sync** ([#96](https://github.com/vig-os/sync-issues-action/issues/96))
+  - Add `withRetry` helper with exponential backoff for 5xx, rate-limit, and network errors
+  - Sanitize GitHub "Unicorn!" HTML error pages into concise messages
+  - Skip individual issues/PRs that fail persistently instead of aborting the entire sync run
+
 ### Changed
 
 - **Post-release replaced by PR-based main-to-dev sync** ([#52](https://github.com/vig-os/sync-issues-action/issues/52))

--- a/dist/index.js
+++ b/dist/index.js
@@ -58378,6 +58378,9 @@ var __importStar = (this && this.__importStar) || (function () {
 })();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.GRAPHQL_BATCH_SIZE = void 0;
+exports.formatGitHubError = formatGitHubError;
+exports.isRetryableError = isRetryableError;
+exports.withRetry = withRetry;
 exports.fetchIssueRelationships = fetchIssueRelationships;
 exports.formatIssueAsMarkdown = formatIssueAsMarkdown;
 exports.formatPRAsMarkdown = formatPRAsMarkdown;
@@ -58389,6 +58392,86 @@ const github = __importStar(__nccwpck_require__(3228));
 const auth_app_1 = __nccwpck_require__(5434);
 const fs = __importStar(__nccwpck_require__(9896));
 const path = __importStar(__nccwpck_require__(6928));
+const MAX_RETRY_ATTEMPTS = 4;
+const INITIAL_RETRY_DELAY_MS = 1000;
+function getErrorStatus(error) {
+    if (typeof error === 'object' && error !== null && 'status' in error) {
+        const status = error.status;
+        if (typeof status === 'number') {
+            return status;
+        }
+    }
+    return undefined;
+}
+function formatGitHubError(error) {
+    if (!(error instanceof Error)) {
+        return 'Unknown error';
+    }
+    const message = error.message;
+    if (message.includes('<!DOCTYPE html>') || message.includes('<title>Unicorn!')) {
+        const status = getErrorStatus(error);
+        return status
+            ? `GitHub returned a ${status} server error`
+            : 'GitHub returned a server error (5xx)';
+    }
+    if (message.length > 500) {
+        return `${message.slice(0, 200)}...`;
+    }
+    return message;
+}
+function isRetryableError(error) {
+    const status = getErrorStatus(error);
+    if (status !== undefined) {
+        if (status >= 500 && status < 600) {
+            return true;
+        }
+        if (status === 429) {
+            return true;
+        }
+        if (status === 403) {
+            const message = error instanceof Error ? error.message : '';
+            if (message.toLowerCase().includes('secondary rate limit')) {
+                return true;
+            }
+        }
+        return false;
+    }
+    if (error instanceof Error) {
+        const message = error.message.toLowerCase();
+        if (message.includes('<!doctype html>') || message.includes('<title>unicorn!')) {
+            return true;
+        }
+        if (message.includes('econnreset') ||
+            message.includes('etimedout') ||
+            message.includes('socket hang up') ||
+            message.includes('network')) {
+            return true;
+        }
+    }
+    return false;
+}
+async function sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+async function withRetry(label, fn) {
+    let lastError;
+    for (let attempt = 1; attempt <= MAX_RETRY_ATTEMPTS; attempt++) {
+        try {
+            return await fn();
+        }
+        catch (error) {
+            lastError = error;
+            if (attempt < MAX_RETRY_ATTEMPTS && isRetryableError(error)) {
+                const delay = INITIAL_RETRY_DELAY_MS * Math.pow(2, attempt - 1);
+                core.warning(`${label} failed (attempt ${attempt}/${MAX_RETRY_ATTEMPTS}): ${formatGitHubError(error)}. Retrying in ${delay}ms...`);
+                await sleep(delay);
+                continue;
+            }
+            throw error;
+        }
+    }
+    throw lastError;
+}
 async function run() {
     try {
         // Get token from input (defaults to github.token via action.yml)
@@ -58493,14 +58576,21 @@ async function syncIssuesToMarkdown(octokit, owner, repo, outputDir, includeClos
     let hasMore = true;
     const allIssues = [];
     while (hasMore) {
-        const { data: issues } = await octokit.rest.issues.listForRepo({
-            owner,
-            repo,
-            state,
-            per_page: perPage,
-            page,
-            ...(updatedSince ? { since: updatedSince } : {}),
-        });
+        let issues;
+        try {
+            ({ data: issues } = await withRetry(`List issues (page ${page})`, () => octokit.rest.issues.listForRepo({
+                owner,
+                repo,
+                state,
+                per_page: perPage,
+                page,
+                ...(updatedSince ? { since: updatedSince } : {}),
+            })));
+        }
+        catch (error) {
+            core.warning(`Failed to list issues (page ${page}): ${formatGitHubError(error)}. Stopping issue sync.`);
+            break;
+        }
         const actualIssues = issues.filter((issue) => !issue.pull_request);
         allIssues.push(...actualIssues);
         hasMore = issues.length === perPage;
@@ -58511,27 +58601,37 @@ async function syncIssuesToMarkdown(octokit, owner, repo, outputDir, includeClos
         ? await fetchIssueRelationships(octokit, owner, repo, issueNumbers)
         : new Map();
     const files = [];
+    let skippedIssues = 0;
     for (const issue of allIssues) {
-        const filename = `issue-${issue.number}.md`;
-        const filepath = path.join(outputDir, filename);
-        const { data: fullIssue } = await octokit.rest.issues.get({
-            owner,
-            repo,
-            issue_number: issue.number,
-        });
-        const comments = await fetchComments(octokit, owner, repo, issue.number);
-        const relationship = relationships.get(issue.number);
-        const content = formatIssueAsMarkdown(fullIssue, comments, relationship);
-        if (forceUpdate || hasContentChanged(content, filepath)) {
-            fs.writeFileSync(filepath, content, 'utf-8');
-            files.push(filepath);
-            core.info(`Synced issue #${issue.number} with ${comments.length} comment(s) to ${filepath}`);
+        try {
+            const filename = `issue-${issue.number}.md`;
+            const filepath = path.join(outputDir, filename);
+            const { data: fullIssue } = await withRetry(`Fetch issue #${issue.number}`, () => octokit.rest.issues.get({
+                owner,
+                repo,
+                issue_number: issue.number,
+            }));
+            const comments = await fetchComments(octokit, owner, repo, issue.number);
+            const relationship = relationships.get(issue.number);
+            const content = formatIssueAsMarkdown(fullIssue, comments, relationship);
+            if (forceUpdate || hasContentChanged(content, filepath)) {
+                fs.writeFileSync(filepath, content, 'utf-8');
+                files.push(filepath);
+                core.info(`Synced issue #${issue.number} with ${comments.length} comment(s) to ${filepath}`);
+            }
+            else {
+                core.info(`Issue #${issue.number} unchanged, skipping write to ${filepath}`);
+            }
         }
-        else {
-            core.info(`Issue #${issue.number} unchanged, skipping write to ${filepath}`);
+        catch (error) {
+            skippedIssues++;
+            core.warning(`Skipping issue #${issue.number}: ${formatGitHubError(error)}`);
         }
     }
-    return { count: allIssues.length, files };
+    if (skippedIssues > 0) {
+        core.warning(`Skipped ${skippedIssues} issue(s) due to API errors.`);
+    }
+    return { count: allIssues.length - skippedIssues, files };
 }
 async function syncPRsToMarkdown(octokit, owner, repo, outputDir, includeClosed, updatedSince, forceUpdate = false) {
     const state = includeClosed ? 'all' : 'open';
@@ -58540,50 +58640,62 @@ async function syncPRsToMarkdown(octokit, owner, repo, outputDir, includeClosed,
     let hasMore = true;
     let prsCount = 0;
     const files = [];
+    let skippedPRs = 0;
     while (hasMore) {
-        const { data: prs } = await octokit.rest.pulls.list({
-            owner,
-            repo,
-            state,
-            per_page: perPage,
-            page,
-            ...(updatedSince
-                ? {
-                    sort: 'updated',
-                    direction: 'desc',
-                }
-                : {}),
-        });
+        let prs;
+        try {
+            ({ data: prs } = await withRetry(`List pull requests (page ${page})`, () => octokit.rest.pulls.list({
+                owner,
+                repo,
+                state,
+                per_page: perPage,
+                page,
+                ...(updatedSince
+                    ? {
+                        sort: 'updated',
+                        direction: 'desc',
+                    }
+                    : {}),
+            })));
+        }
+        catch (error) {
+            core.warning(`Failed to list pull requests (page ${page}): ${formatGitHubError(error)}. Stopping PR sync.`);
+            break;
+        }
         const filteredPRs = updatedSince
             ? prs.filter((pr) => isUpdatedSince(pr.updated_at, updatedSince))
             : prs;
         prsCount += filteredPRs.length;
         for (const pr of filteredPRs) {
-            const filename = `pr-${pr.number}.md`;
-            const filepath = path.join(outputDir, filename);
-            // Fetch full PR details to get all metadata
-            const { data: fullPR } = await octokit.rest.pulls.get({
-                owner,
-                repo,
-                pull_number: pr.number,
-            });
-            // Fetch comments for this PR (issue comments + review comments)
-            const comments = await fetchComments(octokit, owner, repo, pr.number);
-            const reviewComments = await fetchReviewComments(octokit, owner, repo, pr.number);
-            // Fetch commits if PR is closed
-            let commits = [];
-            if (fullPR.state === 'closed') {
-                commits = await fetchPRCommits(octokit, owner, repo, pr.number);
+            try {
+                const filename = `pr-${pr.number}.md`;
+                const filepath = path.join(outputDir, filename);
+                const { data: fullPR } = await withRetry(`Fetch PR #${pr.number}`, () => octokit.rest.pulls.get({
+                    owner,
+                    repo,
+                    pull_number: pr.number,
+                }));
+                const comments = await fetchComments(octokit, owner, repo, pr.number);
+                const reviewComments = await fetchReviewComments(octokit, owner, repo, pr.number);
+                let commits = [];
+                if (fullPR.state === 'closed') {
+                    commits = await fetchPRCommits(octokit, owner, repo, pr.number);
+                }
+                const content = formatPRAsMarkdown(fullPR, comments, reviewComments, commits);
+                if (forceUpdate || hasContentChanged(content, filepath)) {
+                    fs.writeFileSync(filepath, content, 'utf-8');
+                    files.push(filepath);
+                    const commitInfo = commits.length > 0 ? ` with ${commits.length} commit(s)` : '';
+                    core.info(`Synced PR #${pr.number}${commitInfo} with ${comments.length + reviewComments.length} comment(s) to ${filepath}`);
+                }
+                else {
+                    core.info(`PR #${pr.number} unchanged, skipping write to ${filepath}`);
+                }
             }
-            const content = formatPRAsMarkdown(fullPR, comments, reviewComments, commits);
-            if (forceUpdate || hasContentChanged(content, filepath)) {
-                fs.writeFileSync(filepath, content, 'utf-8');
-                files.push(filepath);
-                const commitInfo = commits.length > 0 ? ` with ${commits.length} commit(s)` : '';
-                core.info(`Synced PR #${pr.number}${commitInfo} with ${comments.length + reviewComments.length} comment(s) to ${filepath}`);
-            }
-            else {
-                core.info(`PR #${pr.number} unchanged, skipping write to ${filepath}`);
+            catch (error) {
+                skippedPRs++;
+                prsCount--;
+                core.warning(`Skipping PR #${pr.number}: ${formatGitHubError(error)}`);
             }
         }
         if (updatedSince) {
@@ -58596,6 +58708,9 @@ async function syncPRsToMarkdown(octokit, owner, repo, outputDir, includeClosed,
         }
         page++;
     }
+    if (skippedPRs > 0) {
+        core.warning(`Skipped ${skippedPRs} pull request(s) due to API errors.`);
+    }
     return { count: prsCount, files };
 }
 async function fetchComments(octokit, owner, repo, issueNumber) {
@@ -58605,19 +58720,19 @@ async function fetchComments(octokit, owner, repo, issueNumber) {
     let hasMore = true;
     while (hasMore) {
         try {
-            const { data: pageComments } = await octokit.rest.issues.listComments({
+            const { data: pageComments } = await withRetry(`Fetch comments for #${issueNumber} (page ${page})`, () => octokit.rest.issues.listComments({
                 owner,
                 repo,
                 issue_number: issueNumber,
                 per_page: perPage,
                 page,
-            });
+            }));
             comments.push(...pageComments);
             hasMore = pageComments.length === perPage;
             page++;
         }
         catch (error) {
-            core.warning(`Failed to fetch comments for #${issueNumber}: ${error instanceof Error ? error.message : 'Unknown error'}`);
+            core.warning(`Failed to fetch comments for #${issueNumber}: ${formatGitHubError(error)}`);
             break;
         }
     }
@@ -58643,10 +58758,10 @@ async function fetchIssueRelationships(octokit, owner, repo, issueNumbers) {
       }
     }`;
         try {
-            const response = await octokit.graphql(query, {
+            const response = await withRetry(`Fetch sub-issue relationships (batch ${Math.floor(i / exports.GRAPHQL_BATCH_SIZE) + 1})`, () => octokit.graphql(query, {
                 owner,
                 repo,
-            });
+            }));
             for (const num of batch) {
                 const data = response.repository[`issue_${num}`];
                 if (data) {
@@ -58675,21 +58790,21 @@ async function fetchPRCommits(octokit, owner, repo, pullNumber) {
     let hasMore = true;
     while (hasMore) {
         try {
-            const { data: pageCommits } = await octokit.rest.pulls.listCommits({
+            const { data: pageCommits } = await withRetry(`Fetch commits for PR #${pullNumber} (page ${page})`, () => octokit.rest.pulls.listCommits({
                 owner,
                 repo,
                 pull_number: pullNumber,
                 per_page: perPage,
                 page,
-            });
+            }));
             // Fetch detailed commit info including stats and files
             const commitsWithDetails = await Promise.all(pageCommits.map(async (commit) => {
                 try {
-                    const { data: commitDetail } = await octokit.rest.repos.getCommit({
+                    const { data: commitDetail } = await withRetry(`Fetch commit details ${commit.sha}`, () => octokit.rest.repos.getCommit({
                         owner,
                         repo,
                         ref: commit.sha,
-                    });
+                    }));
                     return {
                         sha: commit.sha,
                         commit: {
@@ -58742,7 +58857,7 @@ async function fetchPRCommits(octokit, owner, repo, pullNumber) {
             page++;
         }
         catch (error) {
-            core.warning(`Failed to fetch commits for PR #${pullNumber}: ${error instanceof Error ? error.message : 'Unknown error'}`);
+            core.warning(`Failed to fetch commits for PR #${pullNumber}: ${formatGitHubError(error)}`);
             break;
         }
     }
@@ -58755,19 +58870,19 @@ async function fetchReviewComments(octokit, owner, repo, pullNumber) {
     let hasMore = true;
     while (hasMore) {
         try {
-            const { data: pageComments } = await octokit.rest.pulls.listReviewComments({
+            const { data: pageComments } = await withRetry(`Fetch review comments for PR #${pullNumber} (page ${page})`, () => octokit.rest.pulls.listReviewComments({
                 owner,
                 repo,
                 pull_number: pullNumber,
                 per_page: perPage,
                 page,
-            });
+            }));
             reviewComments.push(...pageComments);
             hasMore = pageComments.length === perPage;
             page++;
         }
         catch (error) {
-            core.warning(`Failed to fetch review comments for PR #${pullNumber}: ${error instanceof Error ? error.message : 'Unknown error'}`);
+            core.warning(`Failed to fetch review comments for PR #${pullNumber}: ${formatGitHubError(error)}`);
             break;
         }
     }

--- a/dist/src/__tests__/unit/index.test.js
+++ b/dist/src/__tests__/unit/index.test.js
@@ -2777,8 +2777,122 @@ describe('Sync Issues Action', () => {
                 expect(mockSetOutput).toHaveBeenCalledWith('issues-count', 1);
             });
         });
+        describe('retry helpers', () => {
+            it('formatGitHubError sanitizes Unicorn HTML responses', () => {
+                const error = Object.assign(new Error('<!DOCTYPE html><title>Unicorn! &middot; GitHub</title>'), { status: 502 });
+                expect((0, index_1.formatGitHubError)(error)).toBe('GitHub returned a 502 server error');
+            });
+            it('isRetryableError returns true for 5xx and 429 responses', () => {
+                expect((0, index_1.isRetryableError)(Object.assign(new Error('Server error'), { status: 502 }))).toBe(true);
+                expect((0, index_1.isRetryableError)(Object.assign(new Error('Rate limited'), { status: 429 }))).toBe(true);
+                expect((0, index_1.isRetryableError)(Object.assign(new Error('Not found'), { status: 404 }))).toBe(false);
+            });
+            it('withRetry succeeds after a transient 5xx', async () => {
+                jest.useFakeTimers();
+                const fn = jest
+                    .fn()
+                    .mockRejectedValueOnce(Object.assign(new Error('Server error'), { status: 502 }))
+                    .mockResolvedValueOnce('ok');
+                const promise = (0, index_1.withRetry)('test operation', fn);
+                await jest.runAllTimersAsync();
+                await expect(promise).resolves.toBe('ok');
+                expect(fn).toHaveBeenCalledTimes(2);
+                jest.useRealTimers();
+            });
+        });
+        describe('transient API error resilience', () => {
+            const createPR = (number) => ({
+                number,
+                title: `PR ${number}`,
+                body: 'PR Body',
+                state: 'open',
+                labels: [],
+                created_at: '2024-01-01T00:00:00Z',
+                updated_at: '2024-01-02T00:00:00Z',
+                merged_at: null,
+                user: { login: 'pr-user' },
+                html_url: `https://example.com/pr/${number}`,
+                head: { ref: 'feature' },
+                base: { ref: 'main' },
+            });
+            it('retries transient 5xx on pulls.get and completes sync', async () => {
+                mockGetInput.mockImplementation((name) => {
+                    if (name === 'token')
+                        return 'test-token';
+                    if (name === 'sync-issues')
+                        return 'false';
+                    return '';
+                });
+                const pr = createPR(10);
+                const unicornError = Object.assign(new Error('<!DOCTYPE html><title>Unicorn!</title>'), { status: 502 });
+                const mockOctokit = {
+                    rest: {
+                        issues: {
+                            listForRepo: jest.fn(),
+                            get: jest.fn(),
+                            listComments: jest.fn().mockResolvedValue({ data: [] }),
+                        },
+                        pulls: {
+                            list: jest.fn().mockResolvedValue({ data: [pr] }),
+                            get: jest
+                                .fn()
+                                .mockRejectedValueOnce(unicornError)
+                                .mockResolvedValueOnce({ data: pr }),
+                            listReviewComments: jest.fn().mockResolvedValue({ data: [] }),
+                        },
+                    },
+                    graphql: jest.fn(),
+                };
+                setMockOctokit(mockOctokit);
+                jest.useFakeTimers();
+                const runPromise = (0, index_1.run)();
+                await jest.runAllTimersAsync();
+                await runPromise;
+                jest.useRealTimers();
+                expect(mockSetFailed).not.toHaveBeenCalled();
+                expect(mockOctokit.rest.pulls.get).toHaveBeenCalledTimes(2);
+                expect(mockSetOutput).toHaveBeenCalledWith('prs-count', 1);
+            });
+            it('skips persistently failing PR and syncs remaining PRs', async () => {
+                mockGetInput.mockImplementation((name) => {
+                    if (name === 'token')
+                        return 'test-token';
+                    if (name === 'sync-issues')
+                        return 'false';
+                    return '';
+                });
+                const pr10 = createPR(10);
+                const pr11 = createPR(11);
+                const notFoundError = Object.assign(new Error('Not Found'), { status: 404 });
+                const mockOctokit = {
+                    rest: {
+                        issues: {
+                            listForRepo: jest.fn(),
+                            get: jest.fn(),
+                            listComments: jest.fn().mockResolvedValue({ data: [] }),
+                        },
+                        pulls: {
+                            list: jest.fn().mockResolvedValue({ data: [pr10, pr11] }),
+                            get: jest.fn().mockImplementation(({ pull_number }) => {
+                                if (pull_number === 11) {
+                                    return Promise.reject(notFoundError);
+                                }
+                                return Promise.resolve({ data: pr10 });
+                            }),
+                            listReviewComments: jest.fn().mockResolvedValue({ data: [] }),
+                        },
+                    },
+                    graphql: jest.fn(),
+                };
+                setMockOctokit(mockOctokit);
+                await (0, index_1.run)();
+                expect(mockSetFailed).not.toHaveBeenCalled();
+                expect(mockWarning).toHaveBeenCalledWith('Skipping PR #11: Not Found');
+                expect(mockSetOutput).toHaveBeenCalledWith('prs-count', 1);
+            });
+        });
         describe('error handling', () => {
-            it('should handle errors and call setFailed', async () => {
+            it('should warn and continue when issue listing fails', async () => {
                 mockGetInput.mockImplementation((name) => {
                     if (name === 'token')
                         return 'test-token';
@@ -2797,12 +2911,14 @@ describe('Sync Issues Action', () => {
                             listReviewComments: jest.fn().mockResolvedValue({ data: [] }),
                         },
                     },
+                    graphql: jest.fn(),
                 };
                 setMockOctokit(mockOctokit);
                 await (0, index_1.run)();
-                expect(mockSetFailed).toHaveBeenCalledWith('API Error');
+                expect(mockSetFailed).not.toHaveBeenCalled();
+                expect(mockWarning).toHaveBeenCalledWith('Failed to list issues (page 1): API Error. Stopping issue sync.');
             });
-            it('should handle unknown errors', async () => {
+            it('should warn and continue when issue listing fails with unknown errors', async () => {
                 mockGetInput.mockImplementation((name) => {
                     if (name === 'token')
                         return 'test-token';
@@ -2820,10 +2936,12 @@ describe('Sync Issues Action', () => {
                             get: jest.fn(),
                         },
                     },
+                    graphql: jest.fn(),
                 };
                 setMockOctokit(mockOctokit);
                 await (0, index_1.run)();
-                expect(mockSetFailed).toHaveBeenCalledWith('Unknown error occurred');
+                expect(mockSetFailed).not.toHaveBeenCalled();
+                expect(mockWarning).toHaveBeenCalledWith('Failed to list issues (page 1): Unknown error. Stopping issue sync.');
             });
         });
     });

--- a/dist/src/index.d.ts
+++ b/dist/src/index.d.ts
@@ -84,6 +84,9 @@ interface IssueRelationship {
     parent: number | null;
     children: number[];
 }
+export declare function formatGitHubError(error: unknown): string;
+export declare function isRetryableError(error: unknown): boolean;
+export declare function withRetry<T>(label: string, fn: () => Promise<T>): Promise<T>;
 declare function run(): Promise<void>;
 export declare const GRAPHQL_BATCH_SIZE = 50;
 export declare function fetchIssueRelationships(octokit: ReturnType<typeof github.getOctokit>, owner: string, repo: string, issueNumbers: number[]): Promise<Map<number, IssueRelationship>>;

--- a/dist/src/index.js
+++ b/dist/src/index.js
@@ -34,6 +34,9 @@ var __importStar = (this && this.__importStar) || (function () {
 })();
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.GRAPHQL_BATCH_SIZE = void 0;
+exports.formatGitHubError = formatGitHubError;
+exports.isRetryableError = isRetryableError;
+exports.withRetry = withRetry;
 exports.fetchIssueRelationships = fetchIssueRelationships;
 exports.formatIssueAsMarkdown = formatIssueAsMarkdown;
 exports.formatPRAsMarkdown = formatPRAsMarkdown;
@@ -45,6 +48,86 @@ const github = __importStar(require("@actions/github"));
 const auth_app_1 = require("@octokit/auth-app");
 const fs = __importStar(require("fs"));
 const path = __importStar(require("path"));
+const MAX_RETRY_ATTEMPTS = 4;
+const INITIAL_RETRY_DELAY_MS = 1000;
+function getErrorStatus(error) {
+    if (typeof error === 'object' && error !== null && 'status' in error) {
+        const status = error.status;
+        if (typeof status === 'number') {
+            return status;
+        }
+    }
+    return undefined;
+}
+function formatGitHubError(error) {
+    if (!(error instanceof Error)) {
+        return 'Unknown error';
+    }
+    const message = error.message;
+    if (message.includes('<!DOCTYPE html>') || message.includes('<title>Unicorn!')) {
+        const status = getErrorStatus(error);
+        return status
+            ? `GitHub returned a ${status} server error`
+            : 'GitHub returned a server error (5xx)';
+    }
+    if (message.length > 500) {
+        return `${message.slice(0, 200)}...`;
+    }
+    return message;
+}
+function isRetryableError(error) {
+    const status = getErrorStatus(error);
+    if (status !== undefined) {
+        if (status >= 500 && status < 600) {
+            return true;
+        }
+        if (status === 429) {
+            return true;
+        }
+        if (status === 403) {
+            const message = error instanceof Error ? error.message : '';
+            if (message.toLowerCase().includes('secondary rate limit')) {
+                return true;
+            }
+        }
+        return false;
+    }
+    if (error instanceof Error) {
+        const message = error.message.toLowerCase();
+        if (message.includes('<!doctype html>') || message.includes('<title>unicorn!')) {
+            return true;
+        }
+        if (message.includes('econnreset') ||
+            message.includes('etimedout') ||
+            message.includes('socket hang up') ||
+            message.includes('network')) {
+            return true;
+        }
+    }
+    return false;
+}
+async function sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+async function withRetry(label, fn) {
+    let lastError;
+    for (let attempt = 1; attempt <= MAX_RETRY_ATTEMPTS; attempt++) {
+        try {
+            return await fn();
+        }
+        catch (error) {
+            lastError = error;
+            if (attempt < MAX_RETRY_ATTEMPTS && isRetryableError(error)) {
+                const delay = INITIAL_RETRY_DELAY_MS * Math.pow(2, attempt - 1);
+                core.warning(`${label} failed (attempt ${attempt}/${MAX_RETRY_ATTEMPTS}): ${formatGitHubError(error)}. Retrying in ${delay}ms...`);
+                await sleep(delay);
+                continue;
+            }
+            throw error;
+        }
+    }
+    throw lastError;
+}
 async function run() {
     try {
         // Get token from input (defaults to github.token via action.yml)
@@ -149,14 +232,21 @@ async function syncIssuesToMarkdown(octokit, owner, repo, outputDir, includeClos
     let hasMore = true;
     const allIssues = [];
     while (hasMore) {
-        const { data: issues } = await octokit.rest.issues.listForRepo({
-            owner,
-            repo,
-            state,
-            per_page: perPage,
-            page,
-            ...(updatedSince ? { since: updatedSince } : {}),
-        });
+        let issues;
+        try {
+            ({ data: issues } = await withRetry(`List issues (page ${page})`, () => octokit.rest.issues.listForRepo({
+                owner,
+                repo,
+                state,
+                per_page: perPage,
+                page,
+                ...(updatedSince ? { since: updatedSince } : {}),
+            })));
+        }
+        catch (error) {
+            core.warning(`Failed to list issues (page ${page}): ${formatGitHubError(error)}. Stopping issue sync.`);
+            break;
+        }
         const actualIssues = issues.filter((issue) => !issue.pull_request);
         allIssues.push(...actualIssues);
         hasMore = issues.length === perPage;
@@ -167,27 +257,37 @@ async function syncIssuesToMarkdown(octokit, owner, repo, outputDir, includeClos
         ? await fetchIssueRelationships(octokit, owner, repo, issueNumbers)
         : new Map();
     const files = [];
+    let skippedIssues = 0;
     for (const issue of allIssues) {
-        const filename = `issue-${issue.number}.md`;
-        const filepath = path.join(outputDir, filename);
-        const { data: fullIssue } = await octokit.rest.issues.get({
-            owner,
-            repo,
-            issue_number: issue.number,
-        });
-        const comments = await fetchComments(octokit, owner, repo, issue.number);
-        const relationship = relationships.get(issue.number);
-        const content = formatIssueAsMarkdown(fullIssue, comments, relationship);
-        if (forceUpdate || hasContentChanged(content, filepath)) {
-            fs.writeFileSync(filepath, content, 'utf-8');
-            files.push(filepath);
-            core.info(`Synced issue #${issue.number} with ${comments.length} comment(s) to ${filepath}`);
+        try {
+            const filename = `issue-${issue.number}.md`;
+            const filepath = path.join(outputDir, filename);
+            const { data: fullIssue } = await withRetry(`Fetch issue #${issue.number}`, () => octokit.rest.issues.get({
+                owner,
+                repo,
+                issue_number: issue.number,
+            }));
+            const comments = await fetchComments(octokit, owner, repo, issue.number);
+            const relationship = relationships.get(issue.number);
+            const content = formatIssueAsMarkdown(fullIssue, comments, relationship);
+            if (forceUpdate || hasContentChanged(content, filepath)) {
+                fs.writeFileSync(filepath, content, 'utf-8');
+                files.push(filepath);
+                core.info(`Synced issue #${issue.number} with ${comments.length} comment(s) to ${filepath}`);
+            }
+            else {
+                core.info(`Issue #${issue.number} unchanged, skipping write to ${filepath}`);
+            }
         }
-        else {
-            core.info(`Issue #${issue.number} unchanged, skipping write to ${filepath}`);
+        catch (error) {
+            skippedIssues++;
+            core.warning(`Skipping issue #${issue.number}: ${formatGitHubError(error)}`);
         }
     }
-    return { count: allIssues.length, files };
+    if (skippedIssues > 0) {
+        core.warning(`Skipped ${skippedIssues} issue(s) due to API errors.`);
+    }
+    return { count: allIssues.length - skippedIssues, files };
 }
 async function syncPRsToMarkdown(octokit, owner, repo, outputDir, includeClosed, updatedSince, forceUpdate = false) {
     const state = includeClosed ? 'all' : 'open';
@@ -196,50 +296,62 @@ async function syncPRsToMarkdown(octokit, owner, repo, outputDir, includeClosed,
     let hasMore = true;
     let prsCount = 0;
     const files = [];
+    let skippedPRs = 0;
     while (hasMore) {
-        const { data: prs } = await octokit.rest.pulls.list({
-            owner,
-            repo,
-            state,
-            per_page: perPage,
-            page,
-            ...(updatedSince
-                ? {
-                    sort: 'updated',
-                    direction: 'desc',
-                }
-                : {}),
-        });
+        let prs;
+        try {
+            ({ data: prs } = await withRetry(`List pull requests (page ${page})`, () => octokit.rest.pulls.list({
+                owner,
+                repo,
+                state,
+                per_page: perPage,
+                page,
+                ...(updatedSince
+                    ? {
+                        sort: 'updated',
+                        direction: 'desc',
+                    }
+                    : {}),
+            })));
+        }
+        catch (error) {
+            core.warning(`Failed to list pull requests (page ${page}): ${formatGitHubError(error)}. Stopping PR sync.`);
+            break;
+        }
         const filteredPRs = updatedSince
             ? prs.filter((pr) => isUpdatedSince(pr.updated_at, updatedSince))
             : prs;
         prsCount += filteredPRs.length;
         for (const pr of filteredPRs) {
-            const filename = `pr-${pr.number}.md`;
-            const filepath = path.join(outputDir, filename);
-            // Fetch full PR details to get all metadata
-            const { data: fullPR } = await octokit.rest.pulls.get({
-                owner,
-                repo,
-                pull_number: pr.number,
-            });
-            // Fetch comments for this PR (issue comments + review comments)
-            const comments = await fetchComments(octokit, owner, repo, pr.number);
-            const reviewComments = await fetchReviewComments(octokit, owner, repo, pr.number);
-            // Fetch commits if PR is closed
-            let commits = [];
-            if (fullPR.state === 'closed') {
-                commits = await fetchPRCommits(octokit, owner, repo, pr.number);
+            try {
+                const filename = `pr-${pr.number}.md`;
+                const filepath = path.join(outputDir, filename);
+                const { data: fullPR } = await withRetry(`Fetch PR #${pr.number}`, () => octokit.rest.pulls.get({
+                    owner,
+                    repo,
+                    pull_number: pr.number,
+                }));
+                const comments = await fetchComments(octokit, owner, repo, pr.number);
+                const reviewComments = await fetchReviewComments(octokit, owner, repo, pr.number);
+                let commits = [];
+                if (fullPR.state === 'closed') {
+                    commits = await fetchPRCommits(octokit, owner, repo, pr.number);
+                }
+                const content = formatPRAsMarkdown(fullPR, comments, reviewComments, commits);
+                if (forceUpdate || hasContentChanged(content, filepath)) {
+                    fs.writeFileSync(filepath, content, 'utf-8');
+                    files.push(filepath);
+                    const commitInfo = commits.length > 0 ? ` with ${commits.length} commit(s)` : '';
+                    core.info(`Synced PR #${pr.number}${commitInfo} with ${comments.length + reviewComments.length} comment(s) to ${filepath}`);
+                }
+                else {
+                    core.info(`PR #${pr.number} unchanged, skipping write to ${filepath}`);
+                }
             }
-            const content = formatPRAsMarkdown(fullPR, comments, reviewComments, commits);
-            if (forceUpdate || hasContentChanged(content, filepath)) {
-                fs.writeFileSync(filepath, content, 'utf-8');
-                files.push(filepath);
-                const commitInfo = commits.length > 0 ? ` with ${commits.length} commit(s)` : '';
-                core.info(`Synced PR #${pr.number}${commitInfo} with ${comments.length + reviewComments.length} comment(s) to ${filepath}`);
-            }
-            else {
-                core.info(`PR #${pr.number} unchanged, skipping write to ${filepath}`);
+            catch (error) {
+                skippedPRs++;
+                prsCount--;
+                core.warning(`Skipping PR #${pr.number}: ${formatGitHubError(error)}`);
             }
         }
         if (updatedSince) {
@@ -252,6 +364,9 @@ async function syncPRsToMarkdown(octokit, owner, repo, outputDir, includeClosed,
         }
         page++;
     }
+    if (skippedPRs > 0) {
+        core.warning(`Skipped ${skippedPRs} pull request(s) due to API errors.`);
+    }
     return { count: prsCount, files };
 }
 async function fetchComments(octokit, owner, repo, issueNumber) {
@@ -261,19 +376,19 @@ async function fetchComments(octokit, owner, repo, issueNumber) {
     let hasMore = true;
     while (hasMore) {
         try {
-            const { data: pageComments } = await octokit.rest.issues.listComments({
+            const { data: pageComments } = await withRetry(`Fetch comments for #${issueNumber} (page ${page})`, () => octokit.rest.issues.listComments({
                 owner,
                 repo,
                 issue_number: issueNumber,
                 per_page: perPage,
                 page,
-            });
+            }));
             comments.push(...pageComments);
             hasMore = pageComments.length === perPage;
             page++;
         }
         catch (error) {
-            core.warning(`Failed to fetch comments for #${issueNumber}: ${error instanceof Error ? error.message : 'Unknown error'}`);
+            core.warning(`Failed to fetch comments for #${issueNumber}: ${formatGitHubError(error)}`);
             break;
         }
     }
@@ -299,10 +414,10 @@ async function fetchIssueRelationships(octokit, owner, repo, issueNumbers) {
       }
     }`;
         try {
-            const response = await octokit.graphql(query, {
+            const response = await withRetry(`Fetch sub-issue relationships (batch ${Math.floor(i / exports.GRAPHQL_BATCH_SIZE) + 1})`, () => octokit.graphql(query, {
                 owner,
                 repo,
-            });
+            }));
             for (const num of batch) {
                 const data = response.repository[`issue_${num}`];
                 if (data) {
@@ -331,21 +446,21 @@ async function fetchPRCommits(octokit, owner, repo, pullNumber) {
     let hasMore = true;
     while (hasMore) {
         try {
-            const { data: pageCommits } = await octokit.rest.pulls.listCommits({
+            const { data: pageCommits } = await withRetry(`Fetch commits for PR #${pullNumber} (page ${page})`, () => octokit.rest.pulls.listCommits({
                 owner,
                 repo,
                 pull_number: pullNumber,
                 per_page: perPage,
                 page,
-            });
+            }));
             // Fetch detailed commit info including stats and files
             const commitsWithDetails = await Promise.all(pageCommits.map(async (commit) => {
                 try {
-                    const { data: commitDetail } = await octokit.rest.repos.getCommit({
+                    const { data: commitDetail } = await withRetry(`Fetch commit details ${commit.sha}`, () => octokit.rest.repos.getCommit({
                         owner,
                         repo,
                         ref: commit.sha,
-                    });
+                    }));
                     return {
                         sha: commit.sha,
                         commit: {
@@ -398,7 +513,7 @@ async function fetchPRCommits(octokit, owner, repo, pullNumber) {
             page++;
         }
         catch (error) {
-            core.warning(`Failed to fetch commits for PR #${pullNumber}: ${error instanceof Error ? error.message : 'Unknown error'}`);
+            core.warning(`Failed to fetch commits for PR #${pullNumber}: ${formatGitHubError(error)}`);
             break;
         }
     }
@@ -411,19 +526,19 @@ async function fetchReviewComments(octokit, owner, repo, pullNumber) {
     let hasMore = true;
     while (hasMore) {
         try {
-            const { data: pageComments } = await octokit.rest.pulls.listReviewComments({
+            const { data: pageComments } = await withRetry(`Fetch review comments for PR #${pullNumber} (page ${page})`, () => octokit.rest.pulls.listReviewComments({
                 owner,
                 repo,
                 pull_number: pullNumber,
                 per_page: perPage,
                 page,
-            });
+            }));
             reviewComments.push(...pageComments);
             hasMore = pageComments.length === perPage;
             page++;
         }
         catch (error) {
-            core.warning(`Failed to fetch review comments for PR #${pullNumber}: ${error instanceof Error ? error.message : 'Unknown error'}`);
+            core.warning(`Failed to fetch review comments for PR #${pullNumber}: ${formatGitHubError(error)}`);
             break;
         }
     }

--- a/src/__tests__/unit/index.test.ts
+++ b/src/__tests__/unit/index.test.ts
@@ -10,6 +10,9 @@ import {
   formatPRAsMarkdown,
   shiftHeadersToMinLevel,
   fetchIssueRelationships,
+  formatGitHubError,
+  isRetryableError,
+  withRetry,
   GRAPHQL_BATCH_SIZE,
   run,
 } from '../../index';
@@ -3125,8 +3128,146 @@ describe('Sync Issues Action', () => {
       });
     });
 
+    describe('retry helpers', () => {
+      it('formatGitHubError sanitizes Unicorn HTML responses', () => {
+        const error = Object.assign(
+          new Error('<!DOCTYPE html><title>Unicorn! &middot; GitHub</title>'),
+          { status: 502 }
+        );
+
+        expect(formatGitHubError(error)).toBe('GitHub returned a 502 server error');
+      });
+
+      it('isRetryableError returns true for 5xx and 429 responses', () => {
+        expect(isRetryableError(Object.assign(new Error('Server error'), { status: 502 }))).toBe(
+          true
+        );
+        expect(isRetryableError(Object.assign(new Error('Rate limited'), { status: 429 }))).toBe(
+          true
+        );
+        expect(isRetryableError(Object.assign(new Error('Not found'), { status: 404 }))).toBe(
+          false
+        );
+      });
+
+      it('withRetry succeeds after a transient 5xx', async () => {
+        jest.useFakeTimers();
+        const fn = jest
+          .fn()
+          .mockRejectedValueOnce(Object.assign(new Error('Server error'), { status: 502 }))
+          .mockResolvedValueOnce('ok');
+
+        const promise = withRetry('test operation', fn);
+        await jest.runAllTimersAsync();
+        await expect(promise).resolves.toBe('ok');
+        expect(fn).toHaveBeenCalledTimes(2);
+        jest.useRealTimers();
+      });
+    });
+
+    describe('transient API error resilience', () => {
+      const createPR = (number: number) => ({
+        number,
+        title: `PR ${number}`,
+        body: 'PR Body',
+        state: 'open',
+        labels: [],
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-02T00:00:00Z',
+        merged_at: null,
+        user: { login: 'pr-user' },
+        html_url: `https://example.com/pr/${number}`,
+        head: { ref: 'feature' },
+        base: { ref: 'main' },
+      });
+
+      it('retries transient 5xx on pulls.get and completes sync', async () => {
+        mockGetInput.mockImplementation((name: string): string => {
+          if (name === 'token') return 'test-token';
+          if (name === 'sync-issues') return 'false';
+          return '';
+        });
+
+        const pr = createPR(10);
+        const unicornError = Object.assign(
+          new Error('<!DOCTYPE html><title>Unicorn!</title>'),
+          { status: 502 }
+        );
+
+        const mockOctokit = {
+          rest: {
+            issues: {
+              listForRepo: jest.fn(),
+              get: jest.fn(),
+              listComments: jest.fn().mockResolvedValue({ data: [] }),
+            },
+            pulls: {
+              list: jest.fn().mockResolvedValue({ data: [pr] }),
+              get: jest
+                .fn()
+                .mockRejectedValueOnce(unicornError)
+                .mockResolvedValueOnce({ data: pr }),
+              listReviewComments: jest.fn().mockResolvedValue({ data: [] }),
+            },
+          },
+          graphql: jest.fn(),
+        };
+        setMockOctokit(mockOctokit);
+
+        jest.useFakeTimers();
+        const runPromise = run();
+        await jest.runAllTimersAsync();
+        await runPromise;
+        jest.useRealTimers();
+
+        expect(mockSetFailed).not.toHaveBeenCalled();
+        expect(mockOctokit.rest.pulls.get).toHaveBeenCalledTimes(2);
+        expect(mockSetOutput).toHaveBeenCalledWith('prs-count', 1);
+      });
+
+      it('skips persistently failing PR and syncs remaining PRs', async () => {
+        mockGetInput.mockImplementation((name: string): string => {
+          if (name === 'token') return 'test-token';
+          if (name === 'sync-issues') return 'false';
+          return '';
+        });
+
+        const pr10 = createPR(10);
+        const pr11 = createPR(11);
+        const notFoundError = Object.assign(new Error('Not Found'), { status: 404 });
+
+        const mockOctokit = {
+          rest: {
+            issues: {
+              listForRepo: jest.fn(),
+              get: jest.fn(),
+              listComments: jest.fn().mockResolvedValue({ data: [] }),
+            },
+            pulls: {
+              list: jest.fn().mockResolvedValue({ data: [pr10, pr11] }),
+              get: jest.fn().mockImplementation(({ pull_number }) => {
+                if (pull_number === 11) {
+                  return Promise.reject(notFoundError);
+                }
+                return Promise.resolve({ data: pr10 });
+              }),
+              listReviewComments: jest.fn().mockResolvedValue({ data: [] }),
+            },
+          },
+          graphql: jest.fn(),
+        };
+        setMockOctokit(mockOctokit);
+
+        await run();
+
+        expect(mockSetFailed).not.toHaveBeenCalled();
+        expect(mockWarning).toHaveBeenCalledWith('Skipping PR #11: Not Found');
+        expect(mockSetOutput).toHaveBeenCalledWith('prs-count', 1);
+      });
+    });
+
     describe('error handling', () => {
-      it('should handle errors and call setFailed', async () => {
+      it('should warn and continue when issue listing fails', async () => {
         mockGetInput.mockImplementation((name: string): string => {
           if (name === 'token') return 'test-token';
           return '';
@@ -3145,15 +3286,19 @@ describe('Sync Issues Action', () => {
               listReviewComments: jest.fn().mockResolvedValue({ data: [] }),
             },
           },
+          graphql: jest.fn(),
         };
         setMockOctokit(mockOctokit);
 
         await run();
 
-        expect(mockSetFailed).toHaveBeenCalledWith('API Error');
+        expect(mockSetFailed).not.toHaveBeenCalled();
+        expect(mockWarning).toHaveBeenCalledWith(
+          'Failed to list issues (page 1): API Error. Stopping issue sync.'
+        );
       });
 
-      it('should handle unknown errors', async () => {
+      it('should warn and continue when issue listing fails with unknown errors', async () => {
         mockGetInput.mockImplementation((name: string): string => {
           if (name === 'token') return 'test-token';
           return '';
@@ -3171,12 +3316,16 @@ describe('Sync Issues Action', () => {
               get: jest.fn(),
             },
           },
+          graphql: jest.fn(),
         };
         setMockOctokit(mockOctokit);
 
         await run();
 
-        expect(mockSetFailed).toHaveBeenCalledWith('Unknown error occurred');
+        expect(mockSetFailed).not.toHaveBeenCalled();
+        expect(mockWarning).toHaveBeenCalledWith(
+          'Failed to list issues (page 1): Unknown error. Stopping issue sync.'
+        );
       });
     });
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,6 +71,102 @@ interface IssueRelationship {
   children: number[];
 }
 
+const MAX_RETRY_ATTEMPTS = 4;
+const INITIAL_RETRY_DELAY_MS = 1000;
+
+function getErrorStatus(error: unknown): number | undefined {
+  if (typeof error === 'object' && error !== null && 'status' in error) {
+    const status = (error as { status: unknown }).status;
+    if (typeof status === 'number') {
+      return status;
+    }
+  }
+  return undefined;
+}
+
+export function formatGitHubError(error: unknown): string {
+  if (!(error instanceof Error)) {
+    return 'Unknown error';
+  }
+
+  const message = error.message;
+  if (message.includes('<!DOCTYPE html>') || message.includes('<title>Unicorn!')) {
+    const status = getErrorStatus(error);
+    return status
+      ? `GitHub returned a ${status} server error`
+      : 'GitHub returned a server error (5xx)';
+  }
+
+  if (message.length > 500) {
+    return `${message.slice(0, 200)}...`;
+  }
+
+  return message;
+}
+
+export function isRetryableError(error: unknown): boolean {
+  const status = getErrorStatus(error);
+  if (status !== undefined) {
+    if (status >= 500 && status < 600) {
+      return true;
+    }
+    if (status === 429) {
+      return true;
+    }
+    if (status === 403) {
+      const message = error instanceof Error ? error.message : '';
+      if (message.toLowerCase().includes('secondary rate limit')) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  if (error instanceof Error) {
+    const message = error.message.toLowerCase();
+    if (message.includes('<!doctype html>') || message.includes('<title>unicorn!')) {
+      return true;
+    }
+    if (
+      message.includes('econnreset') ||
+      message.includes('etimedout') ||
+      message.includes('socket hang up') ||
+      message.includes('network')
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function withRetry<T>(label: string, fn: () => Promise<T>): Promise<T> {
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= MAX_RETRY_ATTEMPTS; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+      if (attempt < MAX_RETRY_ATTEMPTS && isRetryableError(error)) {
+        const delay = INITIAL_RETRY_DELAY_MS * Math.pow(2, attempt - 1);
+        core.warning(
+          `${label} failed (attempt ${attempt}/${MAX_RETRY_ATTEMPTS}): ${formatGitHubError(error)}. Retrying in ${delay}ms...`
+        );
+        await sleep(delay);
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  throw lastError;
+}
+
 async function run(): Promise<void> {
   try {
     // Get token from input (defaults to github.token via action.yml)
@@ -221,14 +317,24 @@ async function syncIssuesToMarkdown(
   const allIssues: Array<{ number: number; pull_request?: unknown }> = [];
 
   while (hasMore) {
-    const { data: issues } = await octokit.rest.issues.listForRepo({
-      owner,
-      repo,
-      state,
-      per_page: perPage,
-      page,
-      ...(updatedSince ? { since: updatedSince } : {}),
-    });
+    let issues;
+    try {
+      ({ data: issues } = await withRetry(`List issues (page ${page})`, () =>
+        octokit.rest.issues.listForRepo({
+          owner,
+          repo,
+          state,
+          per_page: perPage,
+          page,
+          ...(updatedSince ? { since: updatedSince } : {}),
+        })
+      ));
+    } catch (error) {
+      core.warning(
+        `Failed to list issues (page ${page}): ${formatGitHubError(error)}. Stopping issue sync.`
+      );
+      break;
+    }
 
     const actualIssues = issues.filter((issue) => !issue.pull_request);
     allIssues.push(...actualIssues);
@@ -243,33 +349,46 @@ async function syncIssuesToMarkdown(
     : new Map<number, IssueRelationship>();
 
   const files: string[] = [];
+  let skippedIssues = 0;
+
   for (const issue of allIssues) {
-    const filename = `issue-${issue.number}.md`;
-    const filepath = path.join(outputDir, filename);
+    try {
+      const filename = `issue-${issue.number}.md`;
+      const filepath = path.join(outputDir, filename);
 
-    const { data: fullIssue } = await octokit.rest.issues.get({
-      owner,
-      repo,
-      issue_number: issue.number,
-    });
-
-    const comments = await fetchComments(octokit, owner, repo, issue.number);
-    const relationship = relationships.get(issue.number);
-
-    const content = formatIssueAsMarkdown(fullIssue as Issue, comments, relationship);
-
-    if (forceUpdate || hasContentChanged(content, filepath)) {
-      fs.writeFileSync(filepath, content, 'utf-8');
-      files.push(filepath);
-      core.info(
-        `Synced issue #${issue.number} with ${comments.length} comment(s) to ${filepath}`
+      const { data: fullIssue } = await withRetry(`Fetch issue #${issue.number}`, () =>
+        octokit.rest.issues.get({
+          owner,
+          repo,
+          issue_number: issue.number,
+        })
       );
-    } else {
-      core.info(`Issue #${issue.number} unchanged, skipping write to ${filepath}`);
+
+      const comments = await fetchComments(octokit, owner, repo, issue.number);
+      const relationship = relationships.get(issue.number);
+
+      const content = formatIssueAsMarkdown(fullIssue as Issue, comments, relationship);
+
+      if (forceUpdate || hasContentChanged(content, filepath)) {
+        fs.writeFileSync(filepath, content, 'utf-8');
+        files.push(filepath);
+        core.info(
+          `Synced issue #${issue.number} with ${comments.length} comment(s) to ${filepath}`
+        );
+      } else {
+        core.info(`Issue #${issue.number} unchanged, skipping write to ${filepath}`);
+      }
+    } catch (error) {
+      skippedIssues++;
+      core.warning(`Skipping issue #${issue.number}: ${formatGitHubError(error)}`);
     }
   }
 
-  return { count: allIssues.length, files };
+  if (skippedIssues > 0) {
+    core.warning(`Skipped ${skippedIssues} issue(s) due to API errors.`);
+  }
+
+  return { count: allIssues.length - skippedIssues, files };
 }
 
 async function syncPRsToMarkdown(
@@ -287,21 +406,32 @@ async function syncPRsToMarkdown(
   let hasMore = true;
   let prsCount = 0;
   const files: string[] = [];
+  let skippedPRs = 0;
 
   while (hasMore) {
-    const { data: prs } = await octokit.rest.pulls.list({
-      owner,
-      repo,
-      state,
-      per_page: perPage,
-      page,
-      ...(updatedSince
-        ? {
-            sort: 'updated',
-            direction: 'desc',
-          }
-        : {}),
-    });
+    let prs;
+    try {
+      ({ data: prs } = await withRetry(`List pull requests (page ${page})`, () =>
+        octokit.rest.pulls.list({
+          owner,
+          repo,
+          state,
+          per_page: perPage,
+          page,
+          ...(updatedSince
+            ? {
+                sort: 'updated',
+                direction: 'desc',
+              }
+            : {}),
+        })
+      ));
+    } catch (error) {
+      core.warning(
+        `Failed to list pull requests (page ${page}): ${formatGitHubError(error)}. Stopping PR sync.`
+      );
+      break;
+    }
 
     const filteredPRs = updatedSince
       ? prs.filter((pr) => isUpdatedSince(pr.updated_at, updatedSince))
@@ -309,44 +439,49 @@ async function syncPRsToMarkdown(
     prsCount += filteredPRs.length;
 
     for (const pr of filteredPRs) {
-      const filename = `pr-${pr.number}.md`;
-      const filepath = path.join(outputDir, filename);
+      try {
+        const filename = `pr-${pr.number}.md`;
+        const filepath = path.join(outputDir, filename);
 
-      // Fetch full PR details to get all metadata
-      const { data: fullPR } = await octokit.rest.pulls.get({
-        owner,
-        repo,
-        pull_number: pr.number,
-      });
-
-      // Fetch comments for this PR (issue comments + review comments)
-      const comments = await fetchComments(octokit, owner, repo, pr.number);
-      const reviewComments = await fetchReviewComments(octokit, owner, repo, pr.number);
-
-      // Fetch commits if PR is closed
-      let commits: Array<{
-        sha: string;
-        commit: { message: string; author: { name: string; date: string } };
-        author: { login: string; html_url: string } | null;
-        html_url: string;
-        stats?: { total?: number; additions?: number; deletions?: number };
-        files?: Array<{ filename: string }>;
-      }> = [];
-      if (fullPR.state === 'closed') {
-        commits = await fetchPRCommits(octokit, owner, repo, pr.number);
-      }
-
-      const content = formatPRAsMarkdown(fullPR as PullRequest, comments, reviewComments, commits);
-
-      if (forceUpdate || hasContentChanged(content, filepath)) {
-        fs.writeFileSync(filepath, content, 'utf-8');
-        files.push(filepath);
-        const commitInfo = commits.length > 0 ? ` with ${commits.length} commit(s)` : '';
-        core.info(
-          `Synced PR #${pr.number}${commitInfo} with ${comments.length + reviewComments.length} comment(s) to ${filepath}`
+        const { data: fullPR } = await withRetry(`Fetch PR #${pr.number}`, () =>
+          octokit.rest.pulls.get({
+            owner,
+            repo,
+            pull_number: pr.number,
+          })
         );
-      } else {
-        core.info(`PR #${pr.number} unchanged, skipping write to ${filepath}`);
+
+        const comments = await fetchComments(octokit, owner, repo, pr.number);
+        const reviewComments = await fetchReviewComments(octokit, owner, repo, pr.number);
+
+        let commits: Array<{
+          sha: string;
+          commit: { message: string; author: { name: string; date: string } };
+          author: { login: string; html_url: string } | null;
+          html_url: string;
+          stats?: { total?: number; additions?: number; deletions?: number };
+          files?: Array<{ filename: string }>;
+        }> = [];
+        if (fullPR.state === 'closed') {
+          commits = await fetchPRCommits(octokit, owner, repo, pr.number);
+        }
+
+        const content = formatPRAsMarkdown(fullPR as PullRequest, comments, reviewComments, commits);
+
+        if (forceUpdate || hasContentChanged(content, filepath)) {
+          fs.writeFileSync(filepath, content, 'utf-8');
+          files.push(filepath);
+          const commitInfo = commits.length > 0 ? ` with ${commits.length} commit(s)` : '';
+          core.info(
+            `Synced PR #${pr.number}${commitInfo} with ${comments.length + reviewComments.length} comment(s) to ${filepath}`
+          );
+        } else {
+          core.info(`PR #${pr.number} unchanged, skipping write to ${filepath}`);
+        }
+      } catch (error) {
+        skippedPRs++;
+        prsCount--;
+        core.warning(`Skipping PR #${pr.number}: ${formatGitHubError(error)}`);
       }
     }
 
@@ -358,6 +493,10 @@ async function syncPRsToMarkdown(
       hasMore = prs.length === perPage;
     }
     page++;
+  }
+
+  if (skippedPRs > 0) {
+    core.warning(`Skipped ${skippedPRs} pull request(s) due to API errors.`);
   }
 
   return { count: prsCount, files };
@@ -376,20 +515,24 @@ async function fetchComments(
 
   while (hasMore) {
     try {
-      const { data: pageComments } = await octokit.rest.issues.listComments({
-        owner,
-        repo,
-        issue_number: issueNumber,
-        per_page: perPage,
-        page,
-      });
+      const { data: pageComments } = await withRetry(
+        `Fetch comments for #${issueNumber} (page ${page})`,
+        () =>
+          octokit.rest.issues.listComments({
+            owner,
+            repo,
+            issue_number: issueNumber,
+            per_page: perPage,
+            page,
+          })
+      );
 
       comments.push(...(pageComments as Comment[]));
       hasMore = pageComments.length === perPage;
       page++;
     } catch (error) {
       core.warning(
-        `Failed to fetch comments for #${issueNumber}: ${error instanceof Error ? error.message : 'Unknown error'}`
+        `Failed to fetch comments for #${issueNumber}: ${formatGitHubError(error)}`
       );
       break;
     }
@@ -432,10 +575,14 @@ export async function fetchIssueRelationships(
     }`;
 
     try {
-      const response: any = await octokit.graphql(query, {
-        owner,
-        repo,
-      });
+      const response: any = await withRetry(
+        `Fetch sub-issue relationships (batch ${Math.floor(i / GRAPHQL_BATCH_SIZE) + 1})`,
+        () =>
+          octokit.graphql(query, {
+            owner,
+            repo,
+          })
+      );
 
       for (const num of batch) {
         const data = response.repository[`issue_${num}`];
@@ -493,23 +640,31 @@ async function fetchPRCommits(
 
   while (hasMore) {
     try {
-      const { data: pageCommits } = await octokit.rest.pulls.listCommits({
-        owner,
-        repo,
-        pull_number: pullNumber,
-        per_page: perPage,
-        page,
-      });
+      const { data: pageCommits } = await withRetry(
+        `Fetch commits for PR #${pullNumber} (page ${page})`,
+        () =>
+          octokit.rest.pulls.listCommits({
+            owner,
+            repo,
+            pull_number: pullNumber,
+            per_page: perPage,
+            page,
+          })
+      );
 
       // Fetch detailed commit info including stats and files
       const commitsWithDetails = await Promise.all(
         pageCommits.map(async (commit) => {
           try {
-            const { data: commitDetail } = await octokit.rest.repos.getCommit({
-              owner,
-              repo,
-              ref: commit.sha,
-            });
+            const { data: commitDetail } = await withRetry(
+              `Fetch commit details ${commit.sha}`,
+              () =>
+                octokit.rest.repos.getCommit({
+                  owner,
+                  repo,
+                  ref: commit.sha,
+                })
+            );
             return {
               sha: commit.sha,
               commit: {
@@ -564,7 +719,7 @@ async function fetchPRCommits(
       page++;
     } catch (error) {
       core.warning(
-        `Failed to fetch commits for PR #${pullNumber}: ${error instanceof Error ? error.message : 'Unknown error'}`
+        `Failed to fetch commits for PR #${pullNumber}: ${formatGitHubError(error)}`
       );
       break;
     }
@@ -586,22 +741,24 @@ async function fetchReviewComments(
 
   while (hasMore) {
     try {
-      const { data: pageComments } = await octokit.rest.pulls.listReviewComments({
-        owner,
-        repo,
-        pull_number: pullNumber,
-        per_page: perPage,
-        page,
-      });
+      const { data: pageComments } = await withRetry(
+        `Fetch review comments for PR #${pullNumber} (page ${page})`,
+        () =>
+          octokit.rest.pulls.listReviewComments({
+            owner,
+            repo,
+            pull_number: pullNumber,
+            per_page: perPage,
+            page,
+          })
+      );
 
       reviewComments.push(...(pageComments as ReviewComment[]));
       hasMore = pageComments.length === perPage;
       page++;
     } catch (error) {
       core.warning(
-        `Failed to fetch review comments for PR #${pullNumber}: ${
-          error instanceof Error ? error.message : 'Unknown error'
-        }`
+        `Failed to fetch review comments for PR #${pullNumber}: ${formatGitHubError(error)}`
       );
       break;
     }


### PR DESCRIPTION
## Summary

Fixes the daily-failing **Sync Issues and PRs** scheduled workflow ([#96](https://github.com/vig-os/sync-issues-action/issues/96)).

The action now:
- Retries transient GitHub 5xx / rate-limit / network errors with exponential backoff (`withRetry`)
- Sanitizes GitHub "Unicorn!" HTML error pages into concise messages
- Skips individual issues/PRs that fail persistently instead of aborting the entire sync run

## Root cause

The scheduled workflow was crashing mid-PR-sync when a single unguarded API call returned a transient 5xx (GitHub's "Unicorn!" HTML page). Example failing run: https://github.com/vig-os/sync-issues-action/actions/runs/27257549903

## Changes

- `src/index.ts`: add `withRetry`, `formatGitHubError`, `isRetryableError`; wrap `pulls.list`/`pulls.get` and `issues.listForRepo`/`issues.get`; route existing fetch helpers through retry
- `src/__tests__/unit/index.test.ts`: tests for retry-success, skip-on-persistent-failure, and updated error-handling behavior
- `dist/`: rebuilt bundle

## Test plan

- [x] `npm run lint`
- [x] `npm test` (100 tests pass)

## Release required to stop daily failures

The dogfooding workflow [`.github/workflows/sync-issues.yml`](.github/workflows/sync-issues.yml) pins the action by released SHA (`@bad447d… # v0.2.2`). **A new release (e.g. v0.2.3) and pinned-SHA bump in that workflow is required** before the scheduled runs will pick up this fix.

Closes #96