### PR TITLE
feat: add issues-filter and prs-filter inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- **Sync specific issues/PRs by number or range** ([#55](https://github.com/vig-os/sync-issues-action/issues/55))
+  - New optional `issues-filter` and `prs-filter` inputs accept comma-separated numbers and inclusive ranges (e.g. `1,5,10-20`)
+  - When set, the action fetches only the requested items directly instead of paginating through all issues or pull requests
+
 ### Fixed
 
 - **Retry transient GitHub 5xx errors and skip failing items during sync** ([#96](https://github.com/vig-os/sync-issues-action/issues/96))

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ A GitHub Action that syncs all issues and pull requests from a repository to mar
 | `sync-prs` | Whether to sync pull requests | No | `true` |
 | `include-closed` | Include closed issues/PRs | No | `false` |
 | `updated-since` | Only sync items updated after this ISO8601 timestamp | No | - |
+| `issues-filter` | Comma-separated issue numbers and/or inclusive ranges (e.g. `1,5,10-20`). When set, only these issues are synced | No | - |
+| `prs-filter` | Comma-separated pull request numbers and/or inclusive ranges (e.g. `1,5,10-20`). When set, only these pull requests are synced | No | - |
 | `state-file` | Optional path to store last sync timestamp (use with cache) | No | - |
 | `force-update` | Re-write all synced files even if content is unchanged | No | `false` |
 | `sync-sub-issues` | Sync sub-issue relationships (`parent`/`children`) via GraphQL | No | `true` |

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,12 @@ inputs:
   updated-since:
     description: 'Only sync items updated after this ISO8601 timestamp'
     required: false
+  issues-filter:
+    description: 'Comma-separated issue numbers and/or inclusive ranges (e.g. 1,5,10-20). When set, only these issues are synced.'
+    required: false
+  prs-filter:
+    description: 'Comma-separated pull request numbers and/or inclusive ranges (e.g. 1,5,10-20). When set, only these pull requests are synced.'
+    required: false
   state-file:
     description: 'Optional path to store last sync timestamp (use with cache)'
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -58381,6 +58381,7 @@ exports.GRAPHQL_BATCH_SIZE = void 0;
 exports.formatGitHubError = formatGitHubError;
 exports.isRetryableError = isRetryableError;
 exports.withRetry = withRetry;
+exports.parseNumberFilter = parseNumberFilter;
 exports.fetchIssueRelationships = fetchIssueRelationships;
 exports.formatIssueAsMarkdown = formatIssueAsMarkdown;
 exports.formatPRAsMarkdown = formatPRAsMarkdown;
@@ -58472,6 +58473,49 @@ async function withRetry(label, fn) {
     }
     throw lastError;
 }
+function parseNumberFilter(input) {
+    const trimmed = input.trim();
+    if (!trimmed) {
+        return undefined;
+    }
+    const numbers = new Set();
+    for (const rawToken of trimmed.split(',')) {
+        const token = rawToken.trim();
+        if (!token) {
+            continue;
+        }
+        if (token.includes('-')) {
+            const parts = token.split('-').map((part) => part.trim());
+            if (parts.length !== 2 || !parts[0] || !parts[1]) {
+                throw new Error(`Invalid number filter token: "${rawToken.trim()}"`);
+            }
+            const start = Number(parts[0]);
+            const end = Number(parts[1]);
+            if (!Number.isInteger(start) ||
+                !Number.isInteger(end) ||
+                start <= 0 ||
+                end <= 0) {
+                throw new Error(`Invalid number filter token: "${rawToken.trim()}"`);
+            }
+            if (start > end) {
+                throw new Error(`Invalid number filter range: "${rawToken.trim()}" (start must be <= end)`);
+            }
+            for (let num = start; num <= end; num++) {
+                numbers.add(num);
+            }
+            continue;
+        }
+        const value = Number(token);
+        if (!Number.isInteger(value) || value <= 0) {
+            throw new Error(`Invalid number filter token: "${rawToken.trim()}"`);
+        }
+        numbers.add(value);
+    }
+    if (numbers.size === 0) {
+        return undefined;
+    }
+    return Array.from(numbers).sort((a, b) => a - b);
+}
 async function run() {
     try {
         // Get token from input (defaults to github.token via action.yml)
@@ -58519,6 +58563,8 @@ async function run() {
         const forceUpdate = forceUpdateInput.toLowerCase() === 'true';
         const syncSubIssues = syncSubIssuesInput.toLowerCase() === 'true';
         const updatedSince = resolveUpdatedSince(updatedSinceInput, stateFilePath);
+        const issuesFilter = parseNumberFilter(core.getInput('issues-filter') || '');
+        const prsFilter = parseNumberFilter(core.getInput('prs-filter') || '');
         const octokit = github.getOctokit(tokenToUse);
         const context = github.context;
         const owner = context.repo.owner;
@@ -58537,7 +58583,7 @@ async function run() {
             if (!fs.existsSync(issuesDir)) {
                 fs.mkdirSync(issuesDir, { recursive: true });
             }
-            const issuesResult = await syncIssuesToMarkdown(octokit, owner, repo, issuesDir, includeClosed, updatedSince, forceUpdate, syncSubIssues);
+            const issuesResult = await syncIssuesToMarkdown(octokit, owner, repo, issuesDir, includeClosed, updatedSince, forceUpdate, syncSubIssues, issuesFilter);
             issuesCount = issuesResult.count;
             modifiedFiles.push(...issuesResult.files);
         }
@@ -58546,7 +58592,7 @@ async function run() {
             if (!fs.existsSync(prsDir)) {
                 fs.mkdirSync(prsDir, { recursive: true });
             }
-            const prsResult = await syncPRsToMarkdown(octokit, owner, repo, prsDir, includeClosed, updatedSince, forceUpdate);
+            const prsResult = await syncPRsToMarkdown(octokit, owner, repo, prsDir, includeClosed, updatedSince, forceUpdate, prsFilter);
             prsCount = prsResult.count;
             modifiedFiles.push(...prsResult.files);
         }
@@ -58569,32 +58615,63 @@ async function run() {
         }
     }
 }
-async function syncIssuesToMarkdown(octokit, owner, repo, outputDir, includeClosed, updatedSince, forceUpdate = false, syncSubIssues = true) {
-    const state = includeClosed ? 'all' : 'open';
-    let page = 1;
-    const perPage = 100;
-    let hasMore = true;
+async function syncIssuesToMarkdown(octokit, owner, repo, outputDir, includeClosed, updatedSince, forceUpdate = false, syncSubIssues = true, filterNumbers) {
     const allIssues = [];
-    while (hasMore) {
-        let issues;
-        try {
-            ({ data: issues } = await withRetry(`List issues (page ${page})`, () => octokit.rest.issues.listForRepo({
-                owner,
-                repo,
-                state,
-                per_page: perPage,
-                page,
-                ...(updatedSince ? { since: updatedSince } : {}),
-            })));
+    if (filterNumbers) {
+        for (const issueNumber of filterNumbers) {
+            try {
+                const { data: issue } = await withRetry(`Fetch issue #${issueNumber}`, () => octokit.rest.issues.get({
+                    owner,
+                    repo,
+                    issue_number: issueNumber,
+                }));
+                if (issue.pull_request) {
+                    core.warning(`Skipping #${issueNumber}: not an issue (pull request).`);
+                    continue;
+                }
+                if (!includeClosed && issue.state === 'closed') {
+                    core.info(`Skipping issue #${issueNumber}: closed and include-closed is false.`);
+                    continue;
+                }
+                if (updatedSince && !isUpdatedSince(issue.updated_at, updatedSince)) {
+                    core.info(`Skipping issue #${issueNumber}: not updated since ${updatedSince}.`);
+                    continue;
+                }
+                allIssues.push(issue);
+            }
+            catch (error) {
+                core.warning(`Skipping issue #${issueNumber}: ${formatGitHubError(error)}`);
+            }
         }
-        catch (error) {
-            core.warning(`Failed to list issues (page ${page}): ${formatGitHubError(error)}. Stopping issue sync.`);
-            break;
+    }
+    else {
+        const state = includeClosed ? 'all' : 'open';
+        let page = 1;
+        const perPage = 100;
+        let hasMore = true;
+        while (hasMore) {
+            let issues;
+            try {
+                ({ data: issues } = await withRetry(`List issues (page ${page})`, () => octokit.rest.issues.listForRepo({
+                    owner,
+                    repo,
+                    state,
+                    per_page: perPage,
+                    page,
+                    ...(updatedSince ? { since: updatedSince } : {}),
+                })));
+            }
+            catch (error) {
+                core.warning(`Failed to list issues (page ${page}): ${formatGitHubError(error)}. Stopping issue sync.`);
+                break;
+            }
+            const actualIssues = issues.filter((issue) => !issue.pull_request);
+            for (const issue of actualIssues) {
+                allIssues.push(issue);
+            }
+            hasMore = issues.length === perPage;
+            page++;
         }
-        const actualIssues = issues.filter((issue) => !issue.pull_request);
-        allIssues.push(...actualIssues);
-        hasMore = issues.length === perPage;
-        page++;
     }
     const issueNumbers = allIssues.map((issue) => issue.number);
     const relationships = syncSubIssues
@@ -58606,11 +58683,15 @@ async function syncIssuesToMarkdown(octokit, owner, repo, outputDir, includeClos
         try {
             const filename = `issue-${issue.number}.md`;
             const filepath = path.join(outputDir, filename);
-            const { data: fullIssue } = await withRetry(`Fetch issue #${issue.number}`, () => octokit.rest.issues.get({
-                owner,
-                repo,
-                issue_number: issue.number,
-            }));
+            let fullIssue = issue;
+            if (!filterNumbers) {
+                const { data } = await withRetry(`Fetch issue #${issue.number}`, () => octokit.rest.issues.get({
+                    owner,
+                    repo,
+                    issue_number: issue.number,
+                }));
+                fullIssue = data;
+            }
             const comments = await fetchComments(octokit, owner, repo, issue.number);
             const relationship = relationships.get(issue.number);
             const content = formatIssueAsMarkdown(fullIssue, comments, relationship);
@@ -58633,80 +58714,110 @@ async function syncIssuesToMarkdown(octokit, owner, repo, outputDir, includeClos
     }
     return { count: allIssues.length - skippedIssues, files };
 }
-async function syncPRsToMarkdown(octokit, owner, repo, outputDir, includeClosed, updatedSince, forceUpdate = false) {
-    const state = includeClosed ? 'all' : 'open';
-    let page = 1;
-    const perPage = 100;
-    let hasMore = true;
+async function syncPRsToMarkdown(octokit, owner, repo, outputDir, includeClosed, updatedSince, forceUpdate = false, filterNumbers) {
     let prsCount = 0;
     const files = [];
     let skippedPRs = 0;
-    while (hasMore) {
-        let prs;
-        try {
-            ({ data: prs } = await withRetry(`List pull requests (page ${page})`, () => octokit.rest.pulls.list({
-                owner,
-                repo,
-                state,
-                per_page: perPage,
-                page,
-                ...(updatedSince
-                    ? {
-                        sort: 'updated',
-                        direction: 'desc',
-                    }
-                    : {}),
-            })));
+    const processPR = async (fullPR) => {
+        const filename = `pr-${fullPR.number}.md`;
+        const filepath = path.join(outputDir, filename);
+        const comments = await fetchComments(octokit, owner, repo, fullPR.number);
+        const reviewComments = await fetchReviewComments(octokit, owner, repo, fullPR.number);
+        let commits = [];
+        if (fullPR.state === 'closed') {
+            commits = await fetchPRCommits(octokit, owner, repo, fullPR.number);
         }
-        catch (error) {
-            core.warning(`Failed to list pull requests (page ${page}): ${formatGitHubError(error)}. Stopping PR sync.`);
-            break;
+        const content = formatPRAsMarkdown(fullPR, comments, reviewComments, commits);
+        if (forceUpdate || hasContentChanged(content, filepath)) {
+            fs.writeFileSync(filepath, content, 'utf-8');
+            files.push(filepath);
+            const commitInfo = commits.length > 0 ? ` with ${commits.length} commit(s)` : '';
+            core.info(`Synced PR #${fullPR.number}${commitInfo} with ${comments.length + reviewComments.length} comment(s) to ${filepath}`);
         }
-        const filteredPRs = updatedSince
-            ? prs.filter((pr) => isUpdatedSince(pr.updated_at, updatedSince))
-            : prs;
-        prsCount += filteredPRs.length;
-        for (const pr of filteredPRs) {
+        else {
+            core.info(`PR #${fullPR.number} unchanged, skipping write to ${filepath}`);
+        }
+    };
+    if (filterNumbers) {
+        for (const prNumber of filterNumbers) {
             try {
-                const filename = `pr-${pr.number}.md`;
-                const filepath = path.join(outputDir, filename);
-                const { data: fullPR } = await withRetry(`Fetch PR #${pr.number}`, () => octokit.rest.pulls.get({
+                const { data: fullPR } = await withRetry(`Fetch PR #${prNumber}`, () => octokit.rest.pulls.get({
                     owner,
                     repo,
-                    pull_number: pr.number,
+                    pull_number: prNumber,
                 }));
-                const comments = await fetchComments(octokit, owner, repo, pr.number);
-                const reviewComments = await fetchReviewComments(octokit, owner, repo, pr.number);
-                let commits = [];
-                if (fullPR.state === 'closed') {
-                    commits = await fetchPRCommits(octokit, owner, repo, pr.number);
+                if (!includeClosed && fullPR.state === 'closed') {
+                    core.info(`Skipping PR #${prNumber}: closed and include-closed is false.`);
+                    continue;
                 }
-                const content = formatPRAsMarkdown(fullPR, comments, reviewComments, commits);
-                if (forceUpdate || hasContentChanged(content, filepath)) {
-                    fs.writeFileSync(filepath, content, 'utf-8');
-                    files.push(filepath);
-                    const commitInfo = commits.length > 0 ? ` with ${commits.length} commit(s)` : '';
-                    core.info(`Synced PR #${pr.number}${commitInfo} with ${comments.length + reviewComments.length} comment(s) to ${filepath}`);
+                if (updatedSince && !isUpdatedSince(fullPR.updated_at, updatedSince)) {
+                    core.info(`Skipping PR #${prNumber}: not updated since ${updatedSince}.`);
+                    continue;
                 }
-                else {
-                    core.info(`PR #${pr.number} unchanged, skipping write to ${filepath}`);
-                }
+                await processPR(fullPR);
+                prsCount++;
             }
             catch (error) {
                 skippedPRs++;
-                prsCount--;
-                core.warning(`Skipping PR #${pr.number}: ${formatGitHubError(error)}`);
+                core.warning(`Skipping PR #${prNumber}: ${formatGitHubError(error)}`);
             }
         }
-        if (updatedSince) {
-            const lastPR = prs[prs.length - 1];
-            const olderThanSince = !lastPR || !isUpdatedSince(lastPR.updated_at, updatedSince);
-            hasMore = prs.length === perPage && !olderThanSince;
+    }
+    else {
+        const state = includeClosed ? 'all' : 'open';
+        let page = 1;
+        const perPage = 100;
+        let hasMore = true;
+        while (hasMore) {
+            let prs;
+            try {
+                ({ data: prs } = await withRetry(`List pull requests (page ${page})`, () => octokit.rest.pulls.list({
+                    owner,
+                    repo,
+                    state,
+                    per_page: perPage,
+                    page,
+                    ...(updatedSince
+                        ? {
+                            sort: 'updated',
+                            direction: 'desc',
+                        }
+                        : {}),
+                })));
+            }
+            catch (error) {
+                core.warning(`Failed to list pull requests (page ${page}): ${formatGitHubError(error)}. Stopping PR sync.`);
+                break;
+            }
+            const filteredPRs = updatedSince
+                ? prs.filter((pr) => isUpdatedSince(pr.updated_at, updatedSince))
+                : prs;
+            prsCount += filteredPRs.length;
+            for (const pr of filteredPRs) {
+                try {
+                    const { data: fullPR } = await withRetry(`Fetch PR #${pr.number}`, () => octokit.rest.pulls.get({
+                        owner,
+                        repo,
+                        pull_number: pr.number,
+                    }));
+                    await processPR(fullPR);
+                }
+                catch (error) {
+                    skippedPRs++;
+                    prsCount--;
+                    core.warning(`Skipping PR #${pr.number}: ${formatGitHubError(error)}`);
+                }
+            }
+            if (updatedSince) {
+                const lastPR = prs[prs.length - 1];
+                const olderThanSince = !lastPR || !isUpdatedSince(lastPR.updated_at, updatedSince);
+                hasMore = prs.length === perPage && !olderThanSince;
+            }
+            else {
+                hasMore = prs.length === perPage;
+            }
+            page++;
         }
-        else {
-            hasMore = prs.length === perPage;
-        }
-        page++;
     }
     if (skippedPRs > 0) {
         core.warning(`Skipped ${skippedPRs} pull request(s) due to API errors.`);

--- a/dist/src/__tests__/unit/index.test.js
+++ b/dist/src/__tests__/unit/index.test.js
@@ -1052,6 +1052,30 @@ describe('Sync Issues Action', () => {
             expect(result).toBe('#### Title\n\n###### Max');
         });
     });
+    describe('parseNumberFilter', () => {
+        it('should return undefined for empty input', () => {
+            expect((0, index_1.parseNumberFilter)('')).toBeUndefined();
+            expect((0, index_1.parseNumberFilter)('   ')).toBeUndefined();
+        });
+        it('should parse single number', () => {
+            expect((0, index_1.parseNumberFilter)('42')).toEqual([42]);
+        });
+        it('should parse comma-separated numbers and ranges', () => {
+            expect((0, index_1.parseNumberFilter)('1,5,10-12')).toEqual([1, 5, 10, 11, 12]);
+        });
+        it('should handle whitespace around tokens', () => {
+            expect((0, index_1.parseNumberFilter)(' 1 , 5 , 10 - 12 ')).toEqual([1, 5, 10, 11, 12]);
+        });
+        it('should deduplicate overlapping ranges and numbers', () => {
+            expect((0, index_1.parseNumberFilter)('1,2-3,3,2')).toEqual([1, 2, 3]);
+        });
+        it('should throw on invalid token', () => {
+            expect(() => (0, index_1.parseNumberFilter)('1,abc,5')).toThrow(/invalid/i);
+        });
+        it('should throw on reversed range', () => {
+            expect(() => (0, index_1.parseNumberFilter)('10-5')).toThrow(/range/i);
+        });
+    });
     describe('Input Parameters', () => {
         const mockGetInput = core.getInput;
         const mockGetOctokit = github.getOctokit;
@@ -2798,6 +2822,282 @@ describe('Sync Issues Action', () => {
                 await expect(promise).resolves.toBe('ok');
                 expect(fn).toHaveBeenCalledTimes(2);
                 jest.useRealTimers();
+            });
+        });
+        describe('issues-filter and prs-filter inputs', () => {
+            const createIssue = (number, overrides = {}) => ({
+                number,
+                title: `Issue ${number}`,
+                body: 'Body',
+                state: 'open',
+                labels: [],
+                created_at: '2024-01-01T00:00:00Z',
+                updated_at: '2024-01-02T00:00:00Z',
+                user: { login: 'user1' },
+                html_url: `https://example.com/issue/${number}`,
+                milestone: null,
+                ...overrides,
+            });
+            const createPR = (number, overrides = {}) => ({
+                number,
+                title: `PR ${number}`,
+                body: 'PR Body',
+                state: 'open',
+                labels: [],
+                created_at: '2024-01-01T00:00:00Z',
+                updated_at: '2024-01-02T00:00:00Z',
+                merged_at: null,
+                user: { login: 'pr-user' },
+                html_url: `https://example.com/pr/${number}`,
+                head: { ref: 'feature' },
+                base: { ref: 'main' },
+                ...overrides,
+            });
+            it('should fetch only filtered issues by number without listing', async () => {
+                mockGetInput.mockImplementation((name) => {
+                    if (name === 'token')
+                        return 'test-token';
+                    if (name === 'sync-prs')
+                        return 'false';
+                    if (name === 'issues-filter')
+                        return '1,3';
+                    return '';
+                });
+                const issue1 = createIssue(1);
+                const issue3 = createIssue(3);
+                const mockOctokit = {
+                    rest: {
+                        issues: {
+                            listForRepo: jest.fn(),
+                            get: jest.fn().mockImplementation(({ issue_number }) => {
+                                if (issue_number === 1)
+                                    return Promise.resolve({ data: issue1 });
+                                if (issue_number === 3)
+                                    return Promise.resolve({ data: issue3 });
+                                return Promise.reject(new Error('Not Found'));
+                            }),
+                            listComments: jest.fn().mockResolvedValue({ data: [] }),
+                        },
+                        pulls: {
+                            list: jest.fn(),
+                            get: jest.fn(),
+                        },
+                    },
+                    graphql: jest.fn().mockResolvedValue({ repository: {} }),
+                };
+                setMockOctokit(mockOctokit);
+                await (0, index_1.run)();
+                expect(mockOctokit.rest.issues.listForRepo).not.toHaveBeenCalled();
+                expect(mockOctokit.rest.issues.get).toHaveBeenCalledTimes(2);
+                expect(mockOctokit.rest.issues.get).toHaveBeenCalledWith(expect.objectContaining({ issue_number: 1 }));
+                expect(mockOctokit.rest.issues.get).toHaveBeenCalledWith(expect.objectContaining({ issue_number: 3 }));
+                expect(mockSetOutput).toHaveBeenCalledWith('issues-count', 2);
+            });
+            it('should fetch only filtered PRs by number without listing', async () => {
+                mockGetInput.mockImplementation((name) => {
+                    if (name === 'token')
+                        return 'test-token';
+                    if (name === 'sync-issues')
+                        return 'false';
+                    if (name === 'prs-filter')
+                        return '10-11';
+                    return '';
+                });
+                const pr10 = createPR(10);
+                const pr11 = createPR(11);
+                const mockOctokit = {
+                    rest: {
+                        issues: {
+                            listForRepo: jest.fn(),
+                            get: jest.fn(),
+                            listComments: jest.fn().mockResolvedValue({ data: [] }),
+                        },
+                        pulls: {
+                            list: jest.fn(),
+                            get: jest.fn().mockImplementation(({ pull_number }) => {
+                                if (pull_number === 10)
+                                    return Promise.resolve({ data: pr10 });
+                                if (pull_number === 11)
+                                    return Promise.resolve({ data: pr11 });
+                                return Promise.reject(new Error('Not Found'));
+                            }),
+                            listReviewComments: jest.fn().mockResolvedValue({ data: [] }),
+                        },
+                    },
+                    graphql: jest.fn(),
+                };
+                setMockOctokit(mockOctokit);
+                await (0, index_1.run)();
+                expect(mockOctokit.rest.pulls.list).not.toHaveBeenCalled();
+                expect(mockOctokit.rest.pulls.get).toHaveBeenCalledTimes(2);
+                expect(mockSetOutput).toHaveBeenCalledWith('prs-count', 2);
+            });
+            it('should skip filtered numbers that are pull requests when syncing issues', async () => {
+                mockGetInput.mockImplementation((name) => {
+                    if (name === 'token')
+                        return 'test-token';
+                    if (name === 'sync-prs')
+                        return 'false';
+                    if (name === 'issues-filter')
+                        return '5';
+                    return '';
+                });
+                const prAsIssue = createIssue(5, { pull_request: { url: 'https://example.com/pr/5' } });
+                const mockOctokit = {
+                    rest: {
+                        issues: {
+                            listForRepo: jest.fn(),
+                            get: jest.fn().mockResolvedValue({ data: prAsIssue }),
+                            listComments: jest.fn().mockResolvedValue({ data: [] }),
+                        },
+                        pulls: {
+                            list: jest.fn(),
+                            get: jest.fn(),
+                        },
+                    },
+                    graphql: jest.fn().mockResolvedValue({ repository: {} }),
+                };
+                setMockOctokit(mockOctokit);
+                await (0, index_1.run)();
+                expect(mockWarning).toHaveBeenCalledWith('Skipping #5: not an issue (pull request).');
+                expect(mockSetOutput).toHaveBeenCalledWith('issues-count', 0);
+            });
+            it('should skip closed filtered issues when include-closed is false', async () => {
+                mockGetInput.mockImplementation((name) => {
+                    if (name === 'token')
+                        return 'test-token';
+                    if (name === 'sync-prs')
+                        return 'false';
+                    if (name === 'issues-filter')
+                        return '7';
+                    if (name === 'include-closed')
+                        return 'false';
+                    return '';
+                });
+                const closedIssue = createIssue(7, { state: 'closed' });
+                const mockOctokit = {
+                    rest: {
+                        issues: {
+                            listForRepo: jest.fn(),
+                            get: jest.fn().mockResolvedValue({ data: closedIssue }),
+                            listComments: jest.fn().mockResolvedValue({ data: [] }),
+                        },
+                        pulls: {
+                            list: jest.fn(),
+                            get: jest.fn(),
+                        },
+                    },
+                    graphql: jest.fn().mockResolvedValue({ repository: {} }),
+                };
+                setMockOctokit(mockOctokit);
+                await (0, index_1.run)();
+                expect(mockInfo).toHaveBeenCalledWith('Skipping issue #7: closed and include-closed is false.');
+                expect(mockSetOutput).toHaveBeenCalledWith('issues-count', 0);
+            });
+            it('should sync closed filtered issues when include-closed is true', async () => {
+                mockGetInput.mockImplementation((name) => {
+                    if (name === 'token')
+                        return 'test-token';
+                    if (name === 'sync-prs')
+                        return 'false';
+                    if (name === 'issues-filter')
+                        return '7';
+                    if (name === 'include-closed')
+                        return 'true';
+                    return '';
+                });
+                const closedIssue = createIssue(7, { state: 'closed' });
+                const mockOctokit = {
+                    rest: {
+                        issues: {
+                            listForRepo: jest.fn(),
+                            get: jest.fn().mockResolvedValue({ data: closedIssue }),
+                            listComments: jest.fn().mockResolvedValue({ data: [] }),
+                        },
+                        pulls: {
+                            list: jest.fn(),
+                            get: jest.fn(),
+                        },
+                    },
+                    graphql: jest.fn().mockResolvedValue({ repository: {} }),
+                };
+                setMockOctokit(mockOctokit);
+                await (0, index_1.run)();
+                expect(mockSetOutput).toHaveBeenCalledWith('issues-count', 1);
+            });
+            it('should skip filtered issues not updated since updated-since', async () => {
+                mockGetInput.mockImplementation((name) => {
+                    if (name === 'token')
+                        return 'test-token';
+                    if (name === 'sync-prs')
+                        return 'false';
+                    if (name === 'issues-filter')
+                        return '8';
+                    if (name === 'updated-since')
+                        return '2024-02-01T00:00:00Z';
+                    return '';
+                });
+                const oldIssue = createIssue(8, { updated_at: '2024-01-01T00:00:00Z' });
+                const mockOctokit = {
+                    rest: {
+                        issues: {
+                            listForRepo: jest.fn(),
+                            get: jest.fn().mockResolvedValue({ data: oldIssue }),
+                            listComments: jest.fn().mockResolvedValue({ data: [] }),
+                        },
+                        pulls: {
+                            list: jest.fn(),
+                            get: jest.fn(),
+                        },
+                    },
+                    graphql: jest.fn().mockResolvedValue({ repository: {} }),
+                };
+                setMockOctokit(mockOctokit);
+                await (0, index_1.run)();
+                expect(mockInfo).toHaveBeenCalledWith('Skipping issue #8: not updated since 2024-02-01T00:00:00Z.');
+                expect(mockSetOutput).toHaveBeenCalledWith('issues-count', 0);
+            });
+            it('should warn and continue when a filtered issue does not exist', async () => {
+                mockGetInput.mockImplementation((name) => {
+                    if (name === 'token')
+                        return 'test-token';
+                    if (name === 'sync-prs')
+                        return 'false';
+                    if (name === 'issues-filter')
+                        return '99';
+                    return '';
+                });
+                const notFoundError = Object.assign(new Error('Not Found'), { status: 404 });
+                const mockOctokit = {
+                    rest: {
+                        issues: {
+                            listForRepo: jest.fn(),
+                            get: jest.fn().mockRejectedValue(notFoundError),
+                            listComments: jest.fn().mockResolvedValue({ data: [] }),
+                        },
+                        pulls: {
+                            list: jest.fn(),
+                            get: jest.fn(),
+                        },
+                    },
+                    graphql: jest.fn().mockResolvedValue({ repository: {} }),
+                };
+                setMockOctokit(mockOctokit);
+                await (0, index_1.run)();
+                expect(mockSetFailed).not.toHaveBeenCalled();
+                expect(mockWarning).toHaveBeenCalledWith('Skipping issue #99: Not Found');
+                expect(mockSetOutput).toHaveBeenCalledWith('issues-count', 0);
+            });
+            it('should fail when issues-filter contains invalid tokens', async () => {
+                mockGetInput.mockImplementation((name) => {
+                    if (name === 'token')
+                        return 'test-token';
+                    if (name === 'issues-filter')
+                        return '1,abc';
+                    return '';
+                });
+                await (0, index_1.run)();
+                expect(mockSetFailed).toHaveBeenCalledWith(expect.stringMatching(/invalid/i));
             });
         });
         describe('transient API error resilience', () => {

--- a/dist/src/index.d.ts
+++ b/dist/src/index.d.ts
@@ -87,6 +87,7 @@ interface IssueRelationship {
 export declare function formatGitHubError(error: unknown): string;
 export declare function isRetryableError(error: unknown): boolean;
 export declare function withRetry<T>(label: string, fn: () => Promise<T>): Promise<T>;
+export declare function parseNumberFilter(input: string): number[] | undefined;
 declare function run(): Promise<void>;
 export declare const GRAPHQL_BATCH_SIZE = 50;
 export declare function fetchIssueRelationships(octokit: ReturnType<typeof github.getOctokit>, owner: string, repo: string, issueNumbers: number[]): Promise<Map<number, IssueRelationship>>;

--- a/dist/src/index.js
+++ b/dist/src/index.js
@@ -37,6 +37,7 @@ exports.GRAPHQL_BATCH_SIZE = void 0;
 exports.formatGitHubError = formatGitHubError;
 exports.isRetryableError = isRetryableError;
 exports.withRetry = withRetry;
+exports.parseNumberFilter = parseNumberFilter;
 exports.fetchIssueRelationships = fetchIssueRelationships;
 exports.formatIssueAsMarkdown = formatIssueAsMarkdown;
 exports.formatPRAsMarkdown = formatPRAsMarkdown;
@@ -128,6 +129,49 @@ async function withRetry(label, fn) {
     }
     throw lastError;
 }
+function parseNumberFilter(input) {
+    const trimmed = input.trim();
+    if (!trimmed) {
+        return undefined;
+    }
+    const numbers = new Set();
+    for (const rawToken of trimmed.split(',')) {
+        const token = rawToken.trim();
+        if (!token) {
+            continue;
+        }
+        if (token.includes('-')) {
+            const parts = token.split('-').map((part) => part.trim());
+            if (parts.length !== 2 || !parts[0] || !parts[1]) {
+                throw new Error(`Invalid number filter token: "${rawToken.trim()}"`);
+            }
+            const start = Number(parts[0]);
+            const end = Number(parts[1]);
+            if (!Number.isInteger(start) ||
+                !Number.isInteger(end) ||
+                start <= 0 ||
+                end <= 0) {
+                throw new Error(`Invalid number filter token: "${rawToken.trim()}"`);
+            }
+            if (start > end) {
+                throw new Error(`Invalid number filter range: "${rawToken.trim()}" (start must be <= end)`);
+            }
+            for (let num = start; num <= end; num++) {
+                numbers.add(num);
+            }
+            continue;
+        }
+        const value = Number(token);
+        if (!Number.isInteger(value) || value <= 0) {
+            throw new Error(`Invalid number filter token: "${rawToken.trim()}"`);
+        }
+        numbers.add(value);
+    }
+    if (numbers.size === 0) {
+        return undefined;
+    }
+    return Array.from(numbers).sort((a, b) => a - b);
+}
 async function run() {
     try {
         // Get token from input (defaults to github.token via action.yml)
@@ -175,6 +219,8 @@ async function run() {
         const forceUpdate = forceUpdateInput.toLowerCase() === 'true';
         const syncSubIssues = syncSubIssuesInput.toLowerCase() === 'true';
         const updatedSince = resolveUpdatedSince(updatedSinceInput, stateFilePath);
+        const issuesFilter = parseNumberFilter(core.getInput('issues-filter') || '');
+        const prsFilter = parseNumberFilter(core.getInput('prs-filter') || '');
         const octokit = github.getOctokit(tokenToUse);
         const context = github.context;
         const owner = context.repo.owner;
@@ -193,7 +239,7 @@ async function run() {
             if (!fs.existsSync(issuesDir)) {
                 fs.mkdirSync(issuesDir, { recursive: true });
             }
-            const issuesResult = await syncIssuesToMarkdown(octokit, owner, repo, issuesDir, includeClosed, updatedSince, forceUpdate, syncSubIssues);
+            const issuesResult = await syncIssuesToMarkdown(octokit, owner, repo, issuesDir, includeClosed, updatedSince, forceUpdate, syncSubIssues, issuesFilter);
             issuesCount = issuesResult.count;
             modifiedFiles.push(...issuesResult.files);
         }
@@ -202,7 +248,7 @@ async function run() {
             if (!fs.existsSync(prsDir)) {
                 fs.mkdirSync(prsDir, { recursive: true });
             }
-            const prsResult = await syncPRsToMarkdown(octokit, owner, repo, prsDir, includeClosed, updatedSince, forceUpdate);
+            const prsResult = await syncPRsToMarkdown(octokit, owner, repo, prsDir, includeClosed, updatedSince, forceUpdate, prsFilter);
             prsCount = prsResult.count;
             modifiedFiles.push(...prsResult.files);
         }
@@ -225,32 +271,63 @@ async function run() {
         }
     }
 }
-async function syncIssuesToMarkdown(octokit, owner, repo, outputDir, includeClosed, updatedSince, forceUpdate = false, syncSubIssues = true) {
-    const state = includeClosed ? 'all' : 'open';
-    let page = 1;
-    const perPage = 100;
-    let hasMore = true;
+async function syncIssuesToMarkdown(octokit, owner, repo, outputDir, includeClosed, updatedSince, forceUpdate = false, syncSubIssues = true, filterNumbers) {
     const allIssues = [];
-    while (hasMore) {
-        let issues;
-        try {
-            ({ data: issues } = await withRetry(`List issues (page ${page})`, () => octokit.rest.issues.listForRepo({
-                owner,
-                repo,
-                state,
-                per_page: perPage,
-                page,
-                ...(updatedSince ? { since: updatedSince } : {}),
-            })));
+    if (filterNumbers) {
+        for (const issueNumber of filterNumbers) {
+            try {
+                const { data: issue } = await withRetry(`Fetch issue #${issueNumber}`, () => octokit.rest.issues.get({
+                    owner,
+                    repo,
+                    issue_number: issueNumber,
+                }));
+                if (issue.pull_request) {
+                    core.warning(`Skipping #${issueNumber}: not an issue (pull request).`);
+                    continue;
+                }
+                if (!includeClosed && issue.state === 'closed') {
+                    core.info(`Skipping issue #${issueNumber}: closed and include-closed is false.`);
+                    continue;
+                }
+                if (updatedSince && !isUpdatedSince(issue.updated_at, updatedSince)) {
+                    core.info(`Skipping issue #${issueNumber}: not updated since ${updatedSince}.`);
+                    continue;
+                }
+                allIssues.push(issue);
+            }
+            catch (error) {
+                core.warning(`Skipping issue #${issueNumber}: ${formatGitHubError(error)}`);
+            }
         }
-        catch (error) {
-            core.warning(`Failed to list issues (page ${page}): ${formatGitHubError(error)}. Stopping issue sync.`);
-            break;
+    }
+    else {
+        const state = includeClosed ? 'all' : 'open';
+        let page = 1;
+        const perPage = 100;
+        let hasMore = true;
+        while (hasMore) {
+            let issues;
+            try {
+                ({ data: issues } = await withRetry(`List issues (page ${page})`, () => octokit.rest.issues.listForRepo({
+                    owner,
+                    repo,
+                    state,
+                    per_page: perPage,
+                    page,
+                    ...(updatedSince ? { since: updatedSince } : {}),
+                })));
+            }
+            catch (error) {
+                core.warning(`Failed to list issues (page ${page}): ${formatGitHubError(error)}. Stopping issue sync.`);
+                break;
+            }
+            const actualIssues = issues.filter((issue) => !issue.pull_request);
+            for (const issue of actualIssues) {
+                allIssues.push(issue);
+            }
+            hasMore = issues.length === perPage;
+            page++;
         }
-        const actualIssues = issues.filter((issue) => !issue.pull_request);
-        allIssues.push(...actualIssues);
-        hasMore = issues.length === perPage;
-        page++;
     }
     const issueNumbers = allIssues.map((issue) => issue.number);
     const relationships = syncSubIssues
@@ -262,11 +339,15 @@ async function syncIssuesToMarkdown(octokit, owner, repo, outputDir, includeClos
         try {
             const filename = `issue-${issue.number}.md`;
             const filepath = path.join(outputDir, filename);
-            const { data: fullIssue } = await withRetry(`Fetch issue #${issue.number}`, () => octokit.rest.issues.get({
-                owner,
-                repo,
-                issue_number: issue.number,
-            }));
+            let fullIssue = issue;
+            if (!filterNumbers) {
+                const { data } = await withRetry(`Fetch issue #${issue.number}`, () => octokit.rest.issues.get({
+                    owner,
+                    repo,
+                    issue_number: issue.number,
+                }));
+                fullIssue = data;
+            }
             const comments = await fetchComments(octokit, owner, repo, issue.number);
             const relationship = relationships.get(issue.number);
             const content = formatIssueAsMarkdown(fullIssue, comments, relationship);
@@ -289,80 +370,110 @@ async function syncIssuesToMarkdown(octokit, owner, repo, outputDir, includeClos
     }
     return { count: allIssues.length - skippedIssues, files };
 }
-async function syncPRsToMarkdown(octokit, owner, repo, outputDir, includeClosed, updatedSince, forceUpdate = false) {
-    const state = includeClosed ? 'all' : 'open';
-    let page = 1;
-    const perPage = 100;
-    let hasMore = true;
+async function syncPRsToMarkdown(octokit, owner, repo, outputDir, includeClosed, updatedSince, forceUpdate = false, filterNumbers) {
     let prsCount = 0;
     const files = [];
     let skippedPRs = 0;
-    while (hasMore) {
-        let prs;
-        try {
-            ({ data: prs } = await withRetry(`List pull requests (page ${page})`, () => octokit.rest.pulls.list({
-                owner,
-                repo,
-                state,
-                per_page: perPage,
-                page,
-                ...(updatedSince
-                    ? {
-                        sort: 'updated',
-                        direction: 'desc',
-                    }
-                    : {}),
-            })));
+    const processPR = async (fullPR) => {
+        const filename = `pr-${fullPR.number}.md`;
+        const filepath = path.join(outputDir, filename);
+        const comments = await fetchComments(octokit, owner, repo, fullPR.number);
+        const reviewComments = await fetchReviewComments(octokit, owner, repo, fullPR.number);
+        let commits = [];
+        if (fullPR.state === 'closed') {
+            commits = await fetchPRCommits(octokit, owner, repo, fullPR.number);
         }
-        catch (error) {
-            core.warning(`Failed to list pull requests (page ${page}): ${formatGitHubError(error)}. Stopping PR sync.`);
-            break;
+        const content = formatPRAsMarkdown(fullPR, comments, reviewComments, commits);
+        if (forceUpdate || hasContentChanged(content, filepath)) {
+            fs.writeFileSync(filepath, content, 'utf-8');
+            files.push(filepath);
+            const commitInfo = commits.length > 0 ? ` with ${commits.length} commit(s)` : '';
+            core.info(`Synced PR #${fullPR.number}${commitInfo} with ${comments.length + reviewComments.length} comment(s) to ${filepath}`);
         }
-        const filteredPRs = updatedSince
-            ? prs.filter((pr) => isUpdatedSince(pr.updated_at, updatedSince))
-            : prs;
-        prsCount += filteredPRs.length;
-        for (const pr of filteredPRs) {
+        else {
+            core.info(`PR #${fullPR.number} unchanged, skipping write to ${filepath}`);
+        }
+    };
+    if (filterNumbers) {
+        for (const prNumber of filterNumbers) {
             try {
-                const filename = `pr-${pr.number}.md`;
-                const filepath = path.join(outputDir, filename);
-                const { data: fullPR } = await withRetry(`Fetch PR #${pr.number}`, () => octokit.rest.pulls.get({
+                const { data: fullPR } = await withRetry(`Fetch PR #${prNumber}`, () => octokit.rest.pulls.get({
                     owner,
                     repo,
-                    pull_number: pr.number,
+                    pull_number: prNumber,
                 }));
-                const comments = await fetchComments(octokit, owner, repo, pr.number);
-                const reviewComments = await fetchReviewComments(octokit, owner, repo, pr.number);
-                let commits = [];
-                if (fullPR.state === 'closed') {
-                    commits = await fetchPRCommits(octokit, owner, repo, pr.number);
+                if (!includeClosed && fullPR.state === 'closed') {
+                    core.info(`Skipping PR #${prNumber}: closed and include-closed is false.`);
+                    continue;
                 }
-                const content = formatPRAsMarkdown(fullPR, comments, reviewComments, commits);
-                if (forceUpdate || hasContentChanged(content, filepath)) {
-                    fs.writeFileSync(filepath, content, 'utf-8');
-                    files.push(filepath);
-                    const commitInfo = commits.length > 0 ? ` with ${commits.length} commit(s)` : '';
-                    core.info(`Synced PR #${pr.number}${commitInfo} with ${comments.length + reviewComments.length} comment(s) to ${filepath}`);
+                if (updatedSince && !isUpdatedSince(fullPR.updated_at, updatedSince)) {
+                    core.info(`Skipping PR #${prNumber}: not updated since ${updatedSince}.`);
+                    continue;
                 }
-                else {
-                    core.info(`PR #${pr.number} unchanged, skipping write to ${filepath}`);
-                }
+                await processPR(fullPR);
+                prsCount++;
             }
             catch (error) {
                 skippedPRs++;
-                prsCount--;
-                core.warning(`Skipping PR #${pr.number}: ${formatGitHubError(error)}`);
+                core.warning(`Skipping PR #${prNumber}: ${formatGitHubError(error)}`);
             }
         }
-        if (updatedSince) {
-            const lastPR = prs[prs.length - 1];
-            const olderThanSince = !lastPR || !isUpdatedSince(lastPR.updated_at, updatedSince);
-            hasMore = prs.length === perPage && !olderThanSince;
+    }
+    else {
+        const state = includeClosed ? 'all' : 'open';
+        let page = 1;
+        const perPage = 100;
+        let hasMore = true;
+        while (hasMore) {
+            let prs;
+            try {
+                ({ data: prs } = await withRetry(`List pull requests (page ${page})`, () => octokit.rest.pulls.list({
+                    owner,
+                    repo,
+                    state,
+                    per_page: perPage,
+                    page,
+                    ...(updatedSince
+                        ? {
+                            sort: 'updated',
+                            direction: 'desc',
+                        }
+                        : {}),
+                })));
+            }
+            catch (error) {
+                core.warning(`Failed to list pull requests (page ${page}): ${formatGitHubError(error)}. Stopping PR sync.`);
+                break;
+            }
+            const filteredPRs = updatedSince
+                ? prs.filter((pr) => isUpdatedSince(pr.updated_at, updatedSince))
+                : prs;
+            prsCount += filteredPRs.length;
+            for (const pr of filteredPRs) {
+                try {
+                    const { data: fullPR } = await withRetry(`Fetch PR #${pr.number}`, () => octokit.rest.pulls.get({
+                        owner,
+                        repo,
+                        pull_number: pr.number,
+                    }));
+                    await processPR(fullPR);
+                }
+                catch (error) {
+                    skippedPRs++;
+                    prsCount--;
+                    core.warning(`Skipping PR #${pr.number}: ${formatGitHubError(error)}`);
+                }
+            }
+            if (updatedSince) {
+                const lastPR = prs[prs.length - 1];
+                const olderThanSince = !lastPR || !isUpdatedSince(lastPR.updated_at, updatedSince);
+                hasMore = prs.length === perPage && !olderThanSince;
+            }
+            else {
+                hasMore = prs.length === perPage;
+            }
+            page++;
         }
-        else {
-            hasMore = prs.length === perPage;
-        }
-        page++;
     }
     if (skippedPRs > 0) {
         core.warning(`Skipped ${skippedPRs} pull request(s) due to API errors.`);

--- a/src/__tests__/unit/index.test.ts
+++ b/src/__tests__/unit/index.test.ts
@@ -14,6 +14,7 @@ import {
   isRetryableError,
   withRetry,
   GRAPHQL_BATCH_SIZE,
+  parseNumberFilter,
   run,
 } from '../../index';
 
@@ -1191,6 +1192,37 @@ describe('Sync Issues Action', () => {
       const content = '# Title\n\n###### Max';
       const result = shiftHeadersToMinLevel(content, 4);
       expect(result).toBe('#### Title\n\n###### Max');
+    });
+  });
+
+  describe('parseNumberFilter', () => {
+    it('should return undefined for empty input', () => {
+      expect(parseNumberFilter('')).toBeUndefined();
+      expect(parseNumberFilter('   ')).toBeUndefined();
+    });
+
+    it('should parse single number', () => {
+      expect(parseNumberFilter('42')).toEqual([42]);
+    });
+
+    it('should parse comma-separated numbers and ranges', () => {
+      expect(parseNumberFilter('1,5,10-12')).toEqual([1, 5, 10, 11, 12]);
+    });
+
+    it('should handle whitespace around tokens', () => {
+      expect(parseNumberFilter(' 1 , 5 , 10 - 12 ')).toEqual([1, 5, 10, 11, 12]);
+    });
+
+    it('should deduplicate overlapping ranges and numbers', () => {
+      expect(parseNumberFilter('1,2-3,3,2')).toEqual([1, 2, 3]);
+    });
+
+    it('should throw on invalid token', () => {
+      expect(() => parseNumberFilter('1,abc,5')).toThrow(/invalid/i);
+    });
+
+    it('should throw on reversed range', () => {
+      expect(() => parseNumberFilter('10-5')).toThrow(/range/i);
     });
   });
 
@@ -3162,6 +3194,300 @@ describe('Sync Issues Action', () => {
         await expect(promise).resolves.toBe('ok');
         expect(fn).toHaveBeenCalledTimes(2);
         jest.useRealTimers();
+      });
+    });
+
+    describe('issues-filter and prs-filter inputs', () => {
+      const createIssue = (number: number, overrides: Record<string, unknown> = {}) => ({
+        number,
+        title: `Issue ${number}`,
+        body: 'Body',
+        state: 'open',
+        labels: [],
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-02T00:00:00Z',
+        user: { login: 'user1' },
+        html_url: `https://example.com/issue/${number}`,
+        milestone: null,
+        ...overrides,
+      });
+
+      const createPR = (number: number, overrides: Record<string, unknown> = {}) => ({
+        number,
+        title: `PR ${number}`,
+        body: 'PR Body',
+        state: 'open',
+        labels: [],
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-02T00:00:00Z',
+        merged_at: null,
+        user: { login: 'pr-user' },
+        html_url: `https://example.com/pr/${number}`,
+        head: { ref: 'feature' },
+        base: { ref: 'main' },
+        ...overrides,
+      });
+
+      it('should fetch only filtered issues by number without listing', async () => {
+        mockGetInput.mockImplementation((name: string): string => {
+          if (name === 'token') return 'test-token';
+          if (name === 'sync-prs') return 'false';
+          if (name === 'issues-filter') return '1,3';
+          return '';
+        });
+
+        const issue1 = createIssue(1);
+        const issue3 = createIssue(3);
+
+        const mockOctokit = {
+          rest: {
+            issues: {
+              listForRepo: jest.fn(),
+              get: jest.fn().mockImplementation(({ issue_number }) => {
+                if (issue_number === 1) return Promise.resolve({ data: issue1 });
+                if (issue_number === 3) return Promise.resolve({ data: issue3 });
+                return Promise.reject(new Error('Not Found'));
+              }),
+              listComments: jest.fn().mockResolvedValue({ data: [] }),
+            },
+            pulls: {
+              list: jest.fn(),
+              get: jest.fn(),
+            },
+          },
+          graphql: jest.fn().mockResolvedValue({ repository: {} }),
+        };
+        setMockOctokit(mockOctokit);
+
+        await run();
+
+        expect(mockOctokit.rest.issues.listForRepo).not.toHaveBeenCalled();
+        expect(mockOctokit.rest.issues.get).toHaveBeenCalledTimes(2);
+        expect(mockOctokit.rest.issues.get).toHaveBeenCalledWith(
+          expect.objectContaining({ issue_number: 1 })
+        );
+        expect(mockOctokit.rest.issues.get).toHaveBeenCalledWith(
+          expect.objectContaining({ issue_number: 3 })
+        );
+        expect(mockSetOutput).toHaveBeenCalledWith('issues-count', 2);
+      });
+
+      it('should fetch only filtered PRs by number without listing', async () => {
+        mockGetInput.mockImplementation((name: string): string => {
+          if (name === 'token') return 'test-token';
+          if (name === 'sync-issues') return 'false';
+          if (name === 'prs-filter') return '10-11';
+          return '';
+        });
+
+        const pr10 = createPR(10);
+        const pr11 = createPR(11);
+
+        const mockOctokit = {
+          rest: {
+            issues: {
+              listForRepo: jest.fn(),
+              get: jest.fn(),
+              listComments: jest.fn().mockResolvedValue({ data: [] }),
+            },
+            pulls: {
+              list: jest.fn(),
+              get: jest.fn().mockImplementation(({ pull_number }) => {
+                if (pull_number === 10) return Promise.resolve({ data: pr10 });
+                if (pull_number === 11) return Promise.resolve({ data: pr11 });
+                return Promise.reject(new Error('Not Found'));
+              }),
+              listReviewComments: jest.fn().mockResolvedValue({ data: [] }),
+            },
+          },
+          graphql: jest.fn(),
+        };
+        setMockOctokit(mockOctokit);
+
+        await run();
+
+        expect(mockOctokit.rest.pulls.list).not.toHaveBeenCalled();
+        expect(mockOctokit.rest.pulls.get).toHaveBeenCalledTimes(2);
+        expect(mockSetOutput).toHaveBeenCalledWith('prs-count', 2);
+      });
+
+      it('should skip filtered numbers that are pull requests when syncing issues', async () => {
+        mockGetInput.mockImplementation((name: string): string => {
+          if (name === 'token') return 'test-token';
+          if (name === 'sync-prs') return 'false';
+          if (name === 'issues-filter') return '5';
+          return '';
+        });
+
+        const prAsIssue = createIssue(5, { pull_request: { url: 'https://example.com/pr/5' } });
+
+        const mockOctokit = {
+          rest: {
+            issues: {
+              listForRepo: jest.fn(),
+              get: jest.fn().mockResolvedValue({ data: prAsIssue }),
+              listComments: jest.fn().mockResolvedValue({ data: [] }),
+            },
+            pulls: {
+              list: jest.fn(),
+              get: jest.fn(),
+            },
+          },
+          graphql: jest.fn().mockResolvedValue({ repository: {} }),
+        };
+        setMockOctokit(mockOctokit);
+
+        await run();
+
+        expect(mockWarning).toHaveBeenCalledWith('Skipping #5: not an issue (pull request).');
+        expect(mockSetOutput).toHaveBeenCalledWith('issues-count', 0);
+      });
+
+      it('should skip closed filtered issues when include-closed is false', async () => {
+        mockGetInput.mockImplementation((name: string): string => {
+          if (name === 'token') return 'test-token';
+          if (name === 'sync-prs') return 'false';
+          if (name === 'issues-filter') return '7';
+          if (name === 'include-closed') return 'false';
+          return '';
+        });
+
+        const closedIssue = createIssue(7, { state: 'closed' });
+
+        const mockOctokit = {
+          rest: {
+            issues: {
+              listForRepo: jest.fn(),
+              get: jest.fn().mockResolvedValue({ data: closedIssue }),
+              listComments: jest.fn().mockResolvedValue({ data: [] }),
+            },
+            pulls: {
+              list: jest.fn(),
+              get: jest.fn(),
+            },
+          },
+          graphql: jest.fn().mockResolvedValue({ repository: {} }),
+        };
+        setMockOctokit(mockOctokit);
+
+        await run();
+
+        expect(mockInfo).toHaveBeenCalledWith(
+          'Skipping issue #7: closed and include-closed is false.'
+        );
+        expect(mockSetOutput).toHaveBeenCalledWith('issues-count', 0);
+      });
+
+      it('should sync closed filtered issues when include-closed is true', async () => {
+        mockGetInput.mockImplementation((name: string): string => {
+          if (name === 'token') return 'test-token';
+          if (name === 'sync-prs') return 'false';
+          if (name === 'issues-filter') return '7';
+          if (name === 'include-closed') return 'true';
+          return '';
+        });
+
+        const closedIssue = createIssue(7, { state: 'closed' });
+
+        const mockOctokit = {
+          rest: {
+            issues: {
+              listForRepo: jest.fn(),
+              get: jest.fn().mockResolvedValue({ data: closedIssue }),
+              listComments: jest.fn().mockResolvedValue({ data: [] }),
+            },
+            pulls: {
+              list: jest.fn(),
+              get: jest.fn(),
+            },
+          },
+          graphql: jest.fn().mockResolvedValue({ repository: {} }),
+        };
+        setMockOctokit(mockOctokit);
+
+        await run();
+
+        expect(mockSetOutput).toHaveBeenCalledWith('issues-count', 1);
+      });
+
+      it('should skip filtered issues not updated since updated-since', async () => {
+        mockGetInput.mockImplementation((name: string): string => {
+          if (name === 'token') return 'test-token';
+          if (name === 'sync-prs') return 'false';
+          if (name === 'issues-filter') return '8';
+          if (name === 'updated-since') return '2024-02-01T00:00:00Z';
+          return '';
+        });
+
+        const oldIssue = createIssue(8, { updated_at: '2024-01-01T00:00:00Z' });
+
+        const mockOctokit = {
+          rest: {
+            issues: {
+              listForRepo: jest.fn(),
+              get: jest.fn().mockResolvedValue({ data: oldIssue }),
+              listComments: jest.fn().mockResolvedValue({ data: [] }),
+            },
+            pulls: {
+              list: jest.fn(),
+              get: jest.fn(),
+            },
+          },
+          graphql: jest.fn().mockResolvedValue({ repository: {} }),
+        };
+        setMockOctokit(mockOctokit);
+
+        await run();
+
+        expect(mockInfo).toHaveBeenCalledWith(
+          'Skipping issue #8: not updated since 2024-02-01T00:00:00Z.'
+        );
+        expect(mockSetOutput).toHaveBeenCalledWith('issues-count', 0);
+      });
+
+      it('should warn and continue when a filtered issue does not exist', async () => {
+        mockGetInput.mockImplementation((name: string): string => {
+          if (name === 'token') return 'test-token';
+          if (name === 'sync-prs') return 'false';
+          if (name === 'issues-filter') return '99';
+          return '';
+        });
+
+        const notFoundError = Object.assign(new Error('Not Found'), { status: 404 });
+
+        const mockOctokit = {
+          rest: {
+            issues: {
+              listForRepo: jest.fn(),
+              get: jest.fn().mockRejectedValue(notFoundError),
+              listComments: jest.fn().mockResolvedValue({ data: [] }),
+            },
+            pulls: {
+              list: jest.fn(),
+              get: jest.fn(),
+            },
+          },
+          graphql: jest.fn().mockResolvedValue({ repository: {} }),
+        };
+        setMockOctokit(mockOctokit);
+
+        await run();
+
+        expect(mockSetFailed).not.toHaveBeenCalled();
+        expect(mockWarning).toHaveBeenCalledWith('Skipping issue #99: Not Found');
+        expect(mockSetOutput).toHaveBeenCalledWith('issues-count', 0);
+      });
+
+      it('should fail when issues-filter contains invalid tokens', async () => {
+        mockGetInput.mockImplementation((name: string): string => {
+          if (name === 'token') return 'test-token';
+          if (name === 'issues-filter') return '1,abc';
+          return '';
+        });
+
+        await run();
+
+        expect(mockSetFailed).toHaveBeenCalledWith(expect.stringMatching(/invalid/i));
       });
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -167,6 +167,60 @@ export async function withRetry<T>(label: string, fn: () => Promise<T>): Promise
   throw lastError;
 }
 
+export function parseNumberFilter(input: string): number[] | undefined {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  const numbers = new Set<number>();
+
+  for (const rawToken of trimmed.split(',')) {
+    const token = rawToken.trim();
+    if (!token) {
+      continue;
+    }
+
+    if (token.includes('-')) {
+      const parts = token.split('-').map((part) => part.trim());
+      if (parts.length !== 2 || !parts[0] || !parts[1]) {
+        throw new Error(`Invalid number filter token: "${rawToken.trim()}"`);
+      }
+
+      const start = Number(parts[0]);
+      const end = Number(parts[1]);
+      if (
+        !Number.isInteger(start) ||
+        !Number.isInteger(end) ||
+        start <= 0 ||
+        end <= 0
+      ) {
+        throw new Error(`Invalid number filter token: "${rawToken.trim()}"`);
+      }
+      if (start > end) {
+        throw new Error(`Invalid number filter range: "${rawToken.trim()}" (start must be <= end)`);
+      }
+
+      for (let num = start; num <= end; num++) {
+        numbers.add(num);
+      }
+      continue;
+    }
+
+    const value = Number(token);
+    if (!Number.isInteger(value) || value <= 0) {
+      throw new Error(`Invalid number filter token: "${rawToken.trim()}"`);
+    }
+    numbers.add(value);
+  }
+
+  if (numbers.size === 0) {
+    return undefined;
+  }
+
+  return Array.from(numbers).sort((a, b) => a - b);
+}
+
 async function run(): Promise<void> {
   try {
     // Get token from input (defaults to github.token via action.yml)
@@ -226,6 +280,8 @@ async function run(): Promise<void> {
     const forceUpdate = forceUpdateInput.toLowerCase() === 'true';
     const syncSubIssues = syncSubIssuesInput.toLowerCase() === 'true';
     const updatedSince = resolveUpdatedSince(updatedSinceInput, stateFilePath);
+    const issuesFilter = parseNumberFilter(core.getInput('issues-filter') || '');
+    const prsFilter = parseNumberFilter(core.getInput('prs-filter') || '');
 
     const octokit = github.getOctokit(tokenToUse);
     const context = github.context;
@@ -257,7 +313,8 @@ async function run(): Promise<void> {
         includeClosed,
         updatedSince,
         forceUpdate,
-        syncSubIssues
+        syncSubIssues,
+        issuesFilter
       );
       issuesCount = issuesResult.count;
       modifiedFiles.push(...issuesResult.files);
@@ -275,7 +332,8 @@ async function run(): Promise<void> {
         prsDir,
         includeClosed,
         updatedSince,
-        forceUpdate
+        forceUpdate,
+        prsFilter
       );
       prsCount = prsResult.count;
       modifiedFiles.push(...prsResult.files);
@@ -308,39 +366,76 @@ async function syncIssuesToMarkdown(
   includeClosed: boolean,
   updatedSince?: string,
   forceUpdate = false,
-  syncSubIssues = true
+  syncSubIssues = true,
+  filterNumbers?: number[]
 ): Promise<{ count: number; files: string[] }> {
-  const state = includeClosed ? 'all' : 'open';
-  let page = 1;
-  const perPage = 100;
-  let hasMore = true;
-  const allIssues: Array<{ number: number; pull_request?: unknown }> = [];
+  const allIssues: Issue[] = [];
 
-  while (hasMore) {
-    let issues;
-    try {
-      ({ data: issues } = await withRetry(`List issues (page ${page})`, () =>
-        octokit.rest.issues.listForRepo({
-          owner,
-          repo,
-          state,
-          per_page: perPage,
-          page,
-          ...(updatedSince ? { since: updatedSince } : {}),
-        })
-      ));
-    } catch (error) {
-      core.warning(
-        `Failed to list issues (page ${page}): ${formatGitHubError(error)}. Stopping issue sync.`
-      );
-      break;
+  if (filterNumbers) {
+    for (const issueNumber of filterNumbers) {
+      try {
+        const { data: issue } = await withRetry(`Fetch issue #${issueNumber}`, () =>
+          octokit.rest.issues.get({
+            owner,
+            repo,
+            issue_number: issueNumber,
+          })
+        );
+
+        if (issue.pull_request) {
+          core.warning(`Skipping #${issueNumber}: not an issue (pull request).`);
+          continue;
+        }
+
+        if (!includeClosed && issue.state === 'closed') {
+          core.info(`Skipping issue #${issueNumber}: closed and include-closed is false.`);
+          continue;
+        }
+
+        if (updatedSince && !isUpdatedSince(issue.updated_at, updatedSince)) {
+          core.info(`Skipping issue #${issueNumber}: not updated since ${updatedSince}.`);
+          continue;
+        }
+
+        allIssues.push(issue as Issue);
+      } catch (error) {
+        core.warning(`Skipping issue #${issueNumber}: ${formatGitHubError(error)}`);
+      }
     }
+  } else {
+    const state = includeClosed ? 'all' : 'open';
+    let page = 1;
+    const perPage = 100;
+    let hasMore = true;
 
-    const actualIssues = issues.filter((issue) => !issue.pull_request);
-    allIssues.push(...actualIssues);
+    while (hasMore) {
+      let issues;
+      try {
+        ({ data: issues } = await withRetry(`List issues (page ${page})`, () =>
+          octokit.rest.issues.listForRepo({
+            owner,
+            repo,
+            state,
+            per_page: perPage,
+            page,
+            ...(updatedSince ? { since: updatedSince } : {}),
+          })
+        ));
+      } catch (error) {
+        core.warning(
+          `Failed to list issues (page ${page}): ${formatGitHubError(error)}. Stopping issue sync.`
+        );
+        break;
+      }
 
-    hasMore = issues.length === perPage;
-    page++;
+      const actualIssues = issues.filter((issue) => !issue.pull_request);
+      for (const issue of actualIssues) {
+        allIssues.push(issue as Issue);
+      }
+
+      hasMore = issues.length === perPage;
+      page++;
+    }
   }
 
   const issueNumbers = allIssues.map((issue) => issue.number);
@@ -356,18 +451,22 @@ async function syncIssuesToMarkdown(
       const filename = `issue-${issue.number}.md`;
       const filepath = path.join(outputDir, filename);
 
-      const { data: fullIssue } = await withRetry(`Fetch issue #${issue.number}`, () =>
-        octokit.rest.issues.get({
-          owner,
-          repo,
-          issue_number: issue.number,
-        })
-      );
+      let fullIssue = issue;
+      if (!filterNumbers) {
+        const { data } = await withRetry(`Fetch issue #${issue.number}`, () =>
+          octokit.rest.issues.get({
+            owner,
+            repo,
+            issue_number: issue.number,
+          })
+        );
+        fullIssue = data as Issue;
+      }
 
       const comments = await fetchComments(octokit, owner, repo, issue.number);
       const relationship = relationships.get(issue.number);
 
-      const content = formatIssueAsMarkdown(fullIssue as Issue, comments, relationship);
+      const content = formatIssueAsMarkdown(fullIssue, comments, relationship);
 
       if (forceUpdate || hasContentChanged(content, filepath)) {
         fs.writeFileSync(filepath, content, 'utf-8');
@@ -398,101 +497,137 @@ async function syncPRsToMarkdown(
   outputDir: string,
   includeClosed: boolean,
   updatedSince?: string,
-  forceUpdate = false
+  forceUpdate = false,
+  filterNumbers?: number[]
 ): Promise<{ count: number; files: string[] }> {
-  const state = includeClosed ? 'all' : 'open';
-  let page = 1;
-  const perPage = 100;
-  let hasMore = true;
   let prsCount = 0;
   const files: string[] = [];
   let skippedPRs = 0;
 
-  while (hasMore) {
-    let prs;
-    try {
-      ({ data: prs } = await withRetry(`List pull requests (page ${page})`, () =>
-        octokit.rest.pulls.list({
-          owner,
-          repo,
-          state,
-          per_page: perPage,
-          page,
-          ...(updatedSince
-            ? {
-                sort: 'updated',
-                direction: 'desc',
-              }
-            : {}),
-        })
-      ));
-    } catch (error) {
-      core.warning(
-        `Failed to list pull requests (page ${page}): ${formatGitHubError(error)}. Stopping PR sync.`
-      );
-      break;
+  const processPR = async (fullPR: PullRequest): Promise<void> => {
+    const filename = `pr-${fullPR.number}.md`;
+    const filepath = path.join(outputDir, filename);
+
+    const comments = await fetchComments(octokit, owner, repo, fullPR.number);
+    const reviewComments = await fetchReviewComments(octokit, owner, repo, fullPR.number);
+
+    let commits: Array<{
+      sha: string;
+      commit: { message: string; author: { name: string; date: string } };
+      author: { login: string; html_url: string } | null;
+      html_url: string;
+      stats?: { total?: number; additions?: number; deletions?: number };
+      files?: Array<{ filename: string }>;
+    }> = [];
+    if (fullPR.state === 'closed') {
+      commits = await fetchPRCommits(octokit, owner, repo, fullPR.number);
     }
 
-    const filteredPRs = updatedSince
-      ? prs.filter((pr) => isUpdatedSince(pr.updated_at, updatedSince))
-      : prs;
-    prsCount += filteredPRs.length;
+    const content = formatPRAsMarkdown(fullPR, comments, reviewComments, commits);
 
-    for (const pr of filteredPRs) {
+    if (forceUpdate || hasContentChanged(content, filepath)) {
+      fs.writeFileSync(filepath, content, 'utf-8');
+      files.push(filepath);
+      const commitInfo = commits.length > 0 ? ` with ${commits.length} commit(s)` : '';
+      core.info(
+        `Synced PR #${fullPR.number}${commitInfo} with ${comments.length + reviewComments.length} comment(s) to ${filepath}`
+      );
+    } else {
+      core.info(`PR #${fullPR.number} unchanged, skipping write to ${filepath}`);
+    }
+  };
+
+  if (filterNumbers) {
+    for (const prNumber of filterNumbers) {
       try {
-        const filename = `pr-${pr.number}.md`;
-        const filepath = path.join(outputDir, filename);
-
-        const { data: fullPR } = await withRetry(`Fetch PR #${pr.number}`, () =>
+        const { data: fullPR } = await withRetry(`Fetch PR #${prNumber}`, () =>
           octokit.rest.pulls.get({
             owner,
             repo,
-            pull_number: pr.number,
+            pull_number: prNumber,
           })
         );
 
-        const comments = await fetchComments(octokit, owner, repo, pr.number);
-        const reviewComments = await fetchReviewComments(octokit, owner, repo, pr.number);
-
-        let commits: Array<{
-          sha: string;
-          commit: { message: string; author: { name: string; date: string } };
-          author: { login: string; html_url: string } | null;
-          html_url: string;
-          stats?: { total?: number; additions?: number; deletions?: number };
-          files?: Array<{ filename: string }>;
-        }> = [];
-        if (fullPR.state === 'closed') {
-          commits = await fetchPRCommits(octokit, owner, repo, pr.number);
+        if (!includeClosed && fullPR.state === 'closed') {
+          core.info(`Skipping PR #${prNumber}: closed and include-closed is false.`);
+          continue;
         }
 
-        const content = formatPRAsMarkdown(fullPR as PullRequest, comments, reviewComments, commits);
-
-        if (forceUpdate || hasContentChanged(content, filepath)) {
-          fs.writeFileSync(filepath, content, 'utf-8');
-          files.push(filepath);
-          const commitInfo = commits.length > 0 ? ` with ${commits.length} commit(s)` : '';
-          core.info(
-            `Synced PR #${pr.number}${commitInfo} with ${comments.length + reviewComments.length} comment(s) to ${filepath}`
-          );
-        } else {
-          core.info(`PR #${pr.number} unchanged, skipping write to ${filepath}`);
+        if (updatedSince && !isUpdatedSince(fullPR.updated_at, updatedSince)) {
+          core.info(`Skipping PR #${prNumber}: not updated since ${updatedSince}.`);
+          continue;
         }
+
+        await processPR(fullPR as PullRequest);
+        prsCount++;
       } catch (error) {
         skippedPRs++;
-        prsCount--;
-        core.warning(`Skipping PR #${pr.number}: ${formatGitHubError(error)}`);
+        core.warning(`Skipping PR #${prNumber}: ${formatGitHubError(error)}`);
       }
     }
+  } else {
+    const state = includeClosed ? 'all' : 'open';
+    let page = 1;
+    const perPage = 100;
+    let hasMore = true;
 
-    if (updatedSince) {
-      const lastPR = prs[prs.length - 1];
-      const olderThanSince = !lastPR || !isUpdatedSince(lastPR.updated_at, updatedSince);
-      hasMore = prs.length === perPage && !olderThanSince;
-    } else {
-      hasMore = prs.length === perPage;
+    while (hasMore) {
+      let prs;
+      try {
+        ({ data: prs } = await withRetry(`List pull requests (page ${page})`, () =>
+          octokit.rest.pulls.list({
+            owner,
+            repo,
+            state,
+            per_page: perPage,
+            page,
+            ...(updatedSince
+              ? {
+                  sort: 'updated',
+                  direction: 'desc',
+                }
+              : {}),
+          })
+        ));
+      } catch (error) {
+        core.warning(
+          `Failed to list pull requests (page ${page}): ${formatGitHubError(error)}. Stopping PR sync.`
+        );
+        break;
+      }
+
+      const filteredPRs = updatedSince
+        ? prs.filter((pr) => isUpdatedSince(pr.updated_at, updatedSince))
+        : prs;
+      prsCount += filteredPRs.length;
+
+      for (const pr of filteredPRs) {
+        try {
+          const { data: fullPR } = await withRetry(`Fetch PR #${pr.number}`, () =>
+            octokit.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: pr.number,
+            })
+          );
+
+          await processPR(fullPR as PullRequest);
+        } catch (error) {
+          skippedPRs++;
+          prsCount--;
+          core.warning(`Skipping PR #${pr.number}: ${formatGitHubError(error)}`);
+        }
+      }
+
+      if (updatedSince) {
+        const lastPR = prs[prs.length - 1];
+        const olderThanSince = !lastPR || !isUpdatedSince(lastPR.updated_at, updatedSince);
+        hasMore = prs.length === perPage && !olderThanSince;
+      } else {
+        hasMore = prs.length === perPage;
+      }
+      page++;
     }
-    page++;
   }
 
   if (skippedPRs > 0) {


### PR DESCRIPTION
## Description

Add optional `issues-filter` and `prs-filter` action inputs so users can sync only selected issues and/or pull requests by number or inclusive numeric ranges (e.g. `1,5,10-20`). When a filter is set, the action fetches only the requested items directly via `issues.get` / `pulls.get` instead of paginating through the full repository list. Filters still respect `include-closed` and `updated-since`; invalid filter syntax fails fast with a clear error.

## Type of Change

- [x] `feat` -- New feature
- [ ] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- **`src/index.ts`**
  - Add `parseNumberFilter()` to parse comma-separated numbers and inclusive ranges
  - Read `issues-filter` and `prs-filter` inputs in `run()` and pass parsed numbers to sync functions
  - Add direct-fetch paths in `syncIssuesToMarkdown` and `syncPRsToMarkdown` when filters are set
  - Skip wrong-type items (PRs in issues filter), closed items (when `include-closed` is false), and stale items (when `updated-since` is set)
- **`src/__tests__/unit/index.test.ts`**
  - Add unit tests for `parseNumberFilter`
  - Add integration-style tests for filter inputs (direct fetch, type/state/date filtering, 404 handling, invalid input)
- **`action.yml`**
  - Declare `issues-filter` and `prs-filter` optional inputs
- **`README.md`**
  - Document new inputs in the Options table
- **`CHANGELOG.md`**
  - Add Unreleased entry under Added
- **`dist/`**
  - Rebuilt bundle via `npm run prepare`

## Changelog Entry

### Added

- **Sync specific issues/PRs by number or range** ([#55](https://github.com/vig-os/sync-issues-action/issues/55))
  - New optional `issues-filter` and `prs-filter` inputs accept comma-separated numbers and inclusive ranges (e.g. `1,5,10-20`)
  - When set, the action fetches only the requested items directly instead of paginating through all issues or pull requests

## Testing

- [x] Tests pass locally (`npm test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A — covered by unit tests (115 passing, including 15 new filter-related tests).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Backward compatible: when `issues-filter` / `prs-filter` are unset, behavior is unchanged (full pagination sync). A number present in both filters is handled correctly since each path validates item type independently.

Refs: #55
