### PR TITLE
ci: limit integration tests to a fixed subset of issues and PRs

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -7,19 +7,27 @@
 #   - ci.yml (on PRs, to catch regressions)
 #   - release.yml test job (on finalized code, before tagging)
 #
-# Jobs (all run in parallel):
-#   sync-issues-only  — verify issues-count > 0, output files, frontmatter, github-token
-#   sync-prs-only     — verify prs-count > 0 and output files exist
-#   force-update      — no-op baseline (zero mods) then force (non-zero mods)
-#   include-closed    — verify closed items count >= open-only count
-#   sub-issues        — verify parent/children frontmatter on issues 13/15
-#   sub-issues-off    — verify parent/children are "none" when sync-sub-issues=false
-#   updated-since     — verify future-dated filter produces zero results
-#   state-file        — verify state file creation and ISO8601 content
-#   default-mode      — verify both issues and PRs synced together
+# Fixed subset (issues-filter / prs-filter) — keeps runtime bounded as the repo grows.
+# Update this list if any referenced issue or PR is removed.
+#
+#   Stable CLOSED issues: 4, 8, 13, 15
+#   Stable OPEN issues:   2, 17  (must stay open for include-closed job)
+#   Stable MERGED PRs:    1, 3   (used with include-closed: true)
+#
+# Jobs (all run in parallel; each uses a subset via issues-filter and/or prs-filter):
+#   sync-issues-only  — issues 4,8; verify count, output files, frontmatter, github-token
+#   sync-prs-only     — PRs 1,3; verify prs-count > 0 and output files exist
+#   force-update      — issues 4,8; no-op baseline (zero mods) then force (non-zero mods)
+#   include-closed    — issues 2,17,4,8; verify closed count >= open-only count
+#   sub-issues        — issues 13,15; verify parent/children frontmatter
+#   sub-issues-off    — issues 13,15; verify parent/children are "none" when sync-sub-issues=false
+#   updated-since     — issues 2,17,4,8; verify future-dated filter produces zero results
+#   state-file        — issues 4,8; verify state file creation and ISO8601 content
+#   default-mode      — issues 4,8 + PRs 1,3; verify both issues and PRs synced together
 #
 # Refs: https://github.com/vig-os/sync-issues-action/issues/13
 #       https://github.com/vig-os/sync-issues-action/issues/15
+#       https://github.com/vig-os/sync-issues-action/issues/56
 
 name: Integration Test
 
@@ -57,7 +65,8 @@ jobs:
           output-dir: test-output/issues-only
           sync-issues: 'true'
           sync-prs: 'false'
-          include-closed: 'false'
+          include-closed: 'true'
+          issues-filter: '4,8'
 
       - name: Verify — sync issues only
         env:
@@ -156,7 +165,8 @@ jobs:
           output-dir: test-output/prs-only
           sync-issues: 'false'
           sync-prs: 'true'
-          include-closed: 'false'
+          include-closed: 'true'
+          prs-filter: '1,3'
 
       - name: Verify — sync PRs only
         env:
@@ -223,6 +233,8 @@ jobs:
           output-dir: test-output/force-update
           sync-issues: 'true'
           sync-prs: 'false'
+          include-closed: 'true'
+          issues-filter: '4,8'
 
       - name: Test — re-sync without force (no-op baseline)
         id: sync-noop
@@ -231,6 +243,8 @@ jobs:
           output-dir: test-output/force-update
           sync-issues: 'true'
           sync-prs: 'false'
+          include-closed: 'true'
+          issues-filter: '4,8'
           force-update: 'false'
 
       - name: Verify — no-op produced zero modifications
@@ -253,6 +267,8 @@ jobs:
           output-dir: test-output/force-update
           sync-issues: 'true'
           sync-prs: 'false'
+          include-closed: 'true'
+          issues-filter: '4,8'
           force-update: 'true'
 
       - name: Verify — force update re-wrote files
@@ -290,6 +306,7 @@ jobs:
           sync-issues: 'true'
           sync-prs: 'false'
           include-closed: 'false'
+          issues-filter: '2,17,4,8'
 
       - name: Test — sync with closed included
         id: sync-closed
@@ -299,6 +316,7 @@ jobs:
           sync-issues: 'true'
           sync-prs: 'false'
           include-closed: 'true'
+          issues-filter: '2,17,4,8'
 
       - name: Verify — closed count >= open count
         env:
@@ -343,6 +361,7 @@ jobs:
           sync-prs: 'false'
           sync-sub-issues: 'true'
           include-closed: 'true'
+          issues-filter: '13,15'
 
       - name: Verify — sub-issue relationships
         run: |
@@ -402,6 +421,7 @@ jobs:
           sync-prs: 'false'
           sync-sub-issues: 'false'
           include-closed: 'true'
+          issues-filter: '13,15'
 
       - name: Verify — parent/children are "none" when disabled
         run: |
@@ -448,6 +468,7 @@ jobs:
           output-dir: test-output/updated-since-future
           sync-issues: 'true'
           sync-prs: 'false'
+          issues-filter: '2,17,4,8'
           updated-since: '2099-01-01T00:00:00Z'
 
       - name: Verify — future date produced zero issues
@@ -491,6 +512,8 @@ jobs:
           output-dir: test-output/state-file
           sync-issues: 'true'
           sync-prs: 'false'
+          include-closed: 'true'
+          issues-filter: '4,8'
           state-file: test-output/state-file/.sync-state
 
       - name: Verify — state file exists with ISO8601 timestamp
@@ -540,6 +563,9 @@ jobs:
         uses: ./
         with:
           output-dir: test-output/default-mode
+          include-closed: 'true'
+          issues-filter: '4,8'
+          prs-filter: '1,3'
 
       - name: Verify — both issues and PRs synced
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Sync workflow uses commit-scoped app secrets and manual output target**
   - Update `sync-issues.yml` to use `COMMIT_APP_ID`/`COMMIT_APP_PRIVATE_KEY` for both checkout token generation and action app auth inputs
   - Respect `workflow_dispatch` `output-dir` input in the action call, with `'docs'` as the default fallback
+- **Bound integration test runtime to a fixed subset** ([#56](https://github.com/vig-os/sync-issues-action/issues/56))
+  - Integration test workflow and local test scripts now pass `issues-filter`/`prs-filter` so only a small, stable set of issues and PRs is synced
+  - Keeps test duration bounded as the repository's issue/PR count grows
 
 ## [0.2.2] - 2026-02-26
 

--- a/src/__tests__/integration/test-action.sh
+++ b/src/__tests__/integration/test-action.sh
@@ -41,6 +41,8 @@ main() {
   #   export INPUT_SYNC_ISSUES="true"
   #   export INPUT_SYNC_PRS="true"
   #   export INPUT_INCLUDE_CLOSED="false"
+  #   export INPUT_ISSUES_FILTER="4,8"
+  #   export INPUT_PRS_FILTER="1,3"
   #   export GITHUB_REPOSITORY="my-org/my-repo"
   #   etc.
 
@@ -92,6 +94,10 @@ main() {
   SYNC_PRS=$(printf '%s' "${INPUT_SYNC_PRS:-true}" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')
   local INCLUDE_CLOSED
   INCLUDE_CLOSED=$(printf '%s' "${INPUT_INCLUDE_CLOSED:-true}" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')
+  local ISSUES_FILTER
+  ISSUES_FILTER=$(printf '%s' "${INPUT_ISSUES_FILTER:-4,8}" | tr -d '[:space:]')
+  local PRS_FILTER
+  PRS_FILTER=$(printf '%s' "${INPUT_PRS_FILTER:-1,3}" | tr -d '[:space:]')
 
   # Ensure they're valid boolean values (exactly "true" or "false")
   [ "$SYNC_ISSUES" != "true" ] && [ "$SYNC_ISSUES" != "false" ] && SYNC_ISSUES="true"
@@ -114,6 +120,8 @@ main() {
   echo "  SYNC_ISSUES: $SYNC_ISSUES"
   echo "  SYNC_PRS: $SYNC_PRS"
   echo "  INCLUDE_CLOSED: $INCLUDE_CLOSED"
+  echo "  ISSUES_FILTER: $ISSUES_FILTER"
+  echo "  PRS_FILTER: $PRS_FILTER"
   echo ""
 
   # Run the action with environment variables set correctly
@@ -128,6 +136,8 @@ main() {
     "INPUT_SYNC-ISSUES=$SYNC_ISSUES" \
     "INPUT_SYNC-PRS=$SYNC_PRS" \
     "INPUT_INCLUDE-CLOSED=$INCLUDE_CLOSED" \
+    "INPUT_ISSUES-FILTER=$ISSUES_FILTER" \
+    "INPUT_PRS-FILTER=$PRS_FILTER" \
     node dist/index.js
 
   local EXIT_CODE=$?

--- a/src/__tests__/integration/test-local.sh
+++ b/src/__tests__/integration/test-local.sh
@@ -36,13 +36,17 @@ export GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-vig-os/sync-issues-action}"
 # Create a temporary .env file for local-action
 ENV_FILE=$(mktemp)
 OUTPUT_FILE=$(mktemp)
+ISSUES_FILTER="${INPUT_ISSUES_FILTER:-4,8}"
+PRS_FILTER="${INPUT_PRS_FILTER:-1,3}"
 cat > "$ENV_FILE" <<EOF
 INPUT_TOKEN=$GITHUB_TOKEN
 GITHUB_REPOSITORY=$GITHUB_REPOSITORY
 INPUT_OUTPUT-DIR=test_output
 INPUT_SYNC-ISSUES=true
 INPUT_SYNC-PRS=true
-INPUT_INCLUDE-CLOSED=false
+INPUT_INCLUDE-CLOSED=true
+INPUT_ISSUES-FILTER=$ISSUES_FILTER
+INPUT_PRS-FILTER=$PRS_FILTER
 EOF
 
 # Run local-action with entrypoint and capture outputs


### PR DESCRIPTION
## Summary

Uses `issues-filter` / `prs-filter` (from #55) so integration tests sync only a small, stable subset instead of the full repo, keeping test runtime bounded as issue/PR count grows.

### Fixed subset (documented in workflow header)

| Type | Numbers | Notes |
|------|---------|-------|
| Closed issues | 4, 8, 13, 15 | Stable; 13/15 used by sub-issue jobs |
| Open issues | 2, 17 | Must stay open for `include-closed` job |
| Merged PRs | 1, 3 | Used with `include-closed: true` |

### Changes

- **`.github/workflows/integration-test.yml`** — all 9 jobs now pass filter inputs
- **`src/__tests__/integration/test-action.sh`** — filter env passthrough (defaults `4,8` / `1,3`)
- **`src/__tests__/integration/test-local.sh`** — same defaults, `include-closed: true`
- **`CHANGELOG.md`** — entry under Unreleased > Changed

Closes #56