### PR TITLE
ci: waive pre-devkit commit 9574ee12 in commit-lint base for first release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,19 @@ jobs:
         run: |
           set -euo pipefail
           BASE_SHA="$(git merge-base "origin/${BASE_REF}" "${HEAD_SHA}")"
+          # One-time migration waiver (#113): pre-devkit commit 9574ee12
+          # (PR #97, merged 2026-06-10 before this gate existed) lacks the
+          # mandatory Refs line and is immutable history on dev. Advance the
+          # base past it when the computed range would re-validate it (only
+          # the first release train over pre-gate history does). The ancestor
+          # guard means this can only tighten a range that already contains
+          # the commit — dev-PR ranges start later and are unaffected. Safe to
+          # drop once 0.3.0 is on main (a devkit ci.yml regeneration will).
+          WAIVED=9574ee12ed3c7b80f5e287bc1a274db2e97aa2d2
+          if git merge-base --is-ancestor "${BASE_SHA}" "${WAIVED}" 2>/dev/null; then
+            BASE_SHA="${WAIVED}"
+            echo "Waiver active: base advanced to ${WAIVED} (#113)"
+          fi
           echo "Validating ${BASE_SHA}..${HEAD_SHA} (base: ${BASE_REF})"
           uv run validate-commit-range \
             --base "${BASE_SHA}" \


### PR DESCRIPTION
Unblocks the last red check on release PR #110 (Commit Messages), per approved plan in #113.

The release-PR validation range `merge-base(main, head)..head` spans all pre-devkit history since v0.2.2; commit `9574ee12` (PR #97, merged 2026-06-10 before the gate existed) lacks the mandatory `Refs:` line and is immutable on `dev`. This patch advances `BASE_SHA` past that single SHA behind a `git merge-base --is-ancestor` guard:

- **Release PR (#110)**: merge-base (Feb) is an ancestor of the waived commit → base advances → the one grandfathered commit is skipped, everything after it (June onward, incl. #112 and the freeze commit) is still validated.
- **Dev PRs**: merge-bases are at dev's recent tip, not ancestors of the waived commit → range unchanged.

Verified locally: `validate-commit-range` passes on the release span with the advanced base; `actionlint` + full hook run green. Self-healing: once 0.3.0 lands on `main`, merge-bases move past June, and the next devkit `ci.yml` regeneration drops the patch (hand-patch precedent: `codeql.yml`, vig-os/devkit#1142).

Refs: #113