### PR TITLE
ci: switch release attestation to actions/attest

### DIFF
--- a/.github/workflows/attest-release.yml
+++ b/.github/workflows/attest-release.yml
@@ -14,7 +14,9 @@
 #
 # The subject is the committed dist/index.js AT THE TAG — exactly the file a
 # consumer pinning `@<tag>` executes (action.yml -> main: dist/index.js).
-# Migration of the attest action itself is tracked in #70.
+# Uses actions/attest directly (#70): with only subject-path set it emits the
+# same SLSA build-provenance predicate the attest-build-provenance wrapper
+# produced, under the identical id-token + attestations token grant.
 #
 # Refs: https://github.com/vig-os/sync-issues-action/issues/106
 
@@ -50,6 +52,6 @@ jobs:
           ref: ${{ inputs.ref || github.ref_name }}
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f  # v3
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763  # v4.1.1
         with:
           subject-path: dist/index.js


### PR DESCRIPTION
Migrates the release provenance attestation from `actions/attest-build-provenance` to `actions/attest`, per upstream v4 guidance ("new implementations should use `actions/attest` instead" — attest-build-provenance is now a thin wrapper).

- Drop-in swap: with only `subject-path` set, `actions/attest` emits the same SLSA build-provenance predicate (`https://slsa.dev/provenance/v1`).
- Permissions unchanged (`id-token: write` + `attestations: write`): `create-storage-record` only applies when `push-to-registry: true`, which stays off.
- Pinned to `a1948c3` (v4.1.1).

**Validated end-to-end**: dispatched this branch's workflow against the published `v0.3.0` tag ([run 29509316383](https://github.com/vig-os/sync-issues-action/actions/runs/29509316383)) — `gh attestation verify` passes with the new attestation carrying the identical predicate type as the wrapper-produced ones.

Refs: #70