### PR TITLE
test: pin @github/local-action install to a fixed version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Pin `@github/local-action` in the local integration test script** ([#122](https://github.com/vig-os/sync-issues-action/issues/122))
+  - `test-local.sh` now installs a fixed version instead of the floating latest, resolving the OpenSSF Scorecard `PinnedDependenciesID` alert
+
 ## [v0.3.0](https://github.com/vig-os/sync-issues-action/releases/tag/v0.3.0) - 2026-07-16
 
 ### Added

--- a/src/__tests__/integration/test-local.sh
+++ b/src/__tests__/integration/test-local.sh
@@ -12,7 +12,7 @@ echo "🧪 Testing sync-issues action locally..."
 if ! command -v local-action &> /dev/null; then
     echo "❌ @github/local-action is not installed"
     echo "📦 Installing @github/local-action..."
-    npm install -g @github/local-action
+    npm install -g @github/local-action@7.0.1
 fi
 
 # Build the action first


### PR DESCRIPTION
## Description

Pins the `npm install -g @github/local-action` in `src/__tests__/integration/test-local.sh` to `7.0.1` (current latest), resolving OpenSSF Scorecard code-scanning alert #7 (`PinnedDependenciesID`, medium) — the only Scorecard finding anchored to repo content.

Closes #122

## Type of Change

- [x] `test` -- Adding or updating tests

## Changes Made

- `src/__tests__/integration/test-local.sh`: `npm install -g @github/local-action` → `npm install -g @github/local-action@7.0.1`
- `CHANGELOG.md`: entry under `Unreleased → Security`

## Changelog Entry

### Security
- **Pin `@github/local-action` in the local integration test script** ([#122](https://github.com/vig-os/sync-issues-action/issues/122))
  - `test-local.sh` now installs a fixed version instead of the floating latest, resolving the OpenSSF Scorecard `PinnedDependenciesID` alert

## Testing

- [x] Full hook suite green locally (`prek run --all-files` in the nix dev-shell, incl. shellcheck)
- Dev-only helper script; no runtime or CI code path touched, so no test changes needed

Refs: #122