### PR TITLE
build(npm): hold typescript below v7 in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,13 @@
   "extends": [
     "github>vig-os/sync-issues-action//.github/renovate-default"
   ],
-  "enabledManagers": ["github-actions", "npm"]
+  "enabledManagers": ["github-actions", "npm"],
+  "packageRules": [
+    {
+      "description": "Hold TypeScript on v5/v6: the v7 native (Go) rewrite drops the JS compiler-internal APIs that @vercel/ncc (dist bundling), ts-jest, and typescript-eslint depend on, so the package/test/lint toolchain breaks even though bare tsc compiles. Revisit when those support TS 7. Refs #132, #128.",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["typescript"],
+      "allowedVersions": "<7"
+    }
+  ]
 }


### PR DESCRIPTION
## What

Adds a repo-local `renovate.json` package rule pinning `typescript` to `<7` so Renovate stops proposing the v7 major.

## Why

TypeScript 7.0 is the native Go rewrite (`tsgo`) and drops the JS compiler-internal APIs that the rest of the toolchain reaches into. Verified by rebasing #128 onto `dev` and running the full suite locally:

| Step | Result |
|------|--------|
| `tsc` | ✅ compiles clean |
| `npm install` | ❌ ERESOLVE — `typescript-eslint@8.64.0` peer-deps `typescript ">=4.8.4 <6.1.0"` |
| `npm run package` (ncc → `dist/`) | ❌ crash — `… (reading 'fileExists')` |
| `npm run lint` (typescript-eslint) | ❌ crash — `… (reading 'Cjs')` |
| `npm test` (ts-jest) | ❌ crash — `… (reading 'readFile')` |

Only bare `tsc` works; `@vercel/ncc`, `ts-jest`, and `typescript-eslint` all break. This is also why Renovate's `artifacts` step failed on #128 (it could not regenerate the lockfile).

Revisit when those three ship TypeScript 7-compatible releases.

Closes #132. Supersedes #128 (closed).

Refs: #132