### PR TITLE
build(devkit): adopt vigOS devkit 1.4.0 (direnv) — validates 1.4.0-rc2

### DIFF
--- a/.github/actions/resolve-toolchain/action.yml
+++ b/.github/actions/resolve-toolchain/action.yml
@@ -59,6 +59,12 @@ outputs:
   floating-tags:
     description: Floating tag levels from DEVKIT_FLOATING_TAGS (subset of major,minor; empty => off)
     value: ${{ steps.resolve.outputs.floating-tags }}
+  runner-json:
+    description: >-
+      JSON array of runner labels from DEVKIT_CI_RUNNER (comma-separated), for
+      use with fromJSON() in `runs-on`. Defaults to ["ubuntu-24.04"] when the
+      key is absent.
+    value: ${{ steps.resolve.outputs.runner-json }}
 
 runs:
   using: composite
@@ -76,6 +82,7 @@ runs:
         LEGACY_VERSION=""
         TAG_PREFIX=""
         FLOATING_TAGS=""
+        CI_RUNNER=""
 
         if [[ -f .vig-os ]]; then
           # Tolerant KEY=VALUE parsing shared with resolve-image (#781): capture
@@ -87,7 +94,7 @@ runs:
             [[ "$line" =~ ^[[:space:]]*# ]] && continue
 
             case "$line" in
-              DEVKIT_MODE=*|DEVKIT_VERSION=*|DEVCONTAINER_VERSION=*|DEVKIT_TAG_PREFIX=*|DEVKIT_FLOATING_TAGS=*)
+              DEVKIT_MODE=*|DEVKIT_VERSION=*|DEVCONTAINER_VERSION=*|DEVKIT_TAG_PREFIX=*|DEVKIT_FLOATING_TAGS=*|DEVKIT_CI_RUNNER=*)
                 key="${line%%=*}"
                 value="${line#*=}"
                 value="${value#"${value%%[![:space:]]*}"}"
@@ -105,6 +112,7 @@ runs:
                   DEVCONTAINER_VERSION) LEGACY_VERSION="$value" ;;
                   DEVKIT_TAG_PREFIX) TAG_PREFIX="$value" ;;
                   DEVKIT_FLOATING_TAGS) FLOATING_TAGS="$value" ;;
+                  DEVKIT_CI_RUNNER) CI_RUNNER="$value" ;;
                 esac
                 ;;
             esac
@@ -136,6 +144,28 @@ runs:
         # empty by default (= off). Only promote-release consumes it, force-moving
         # <prefix>X / <prefix>X.Y at the final release commit.
         echo "floating-tags=$FLOATING_TAGS" >> "$GITHUB_OUTPUT"
+
+        # CI runner labels (#1173): DEVKIT_CI_RUNNER is a comma-separated label
+        # list routed into `runs-on` via fromJSON() by the downstream CI
+        # jobs. Absent => the hosted default, so existing consumers are unchanged.
+        # Emitted for every mode, ALWAYS a valid JSON array (single label =>
+        # ["ubuntu-24.04"]); whitespace around each label is trimmed and empty
+        # entries dropped so a trailing/spaced comma never yields a blank label.
+        CI_RUNNER="${CI_RUNNER:-ubuntu-24.04}"
+        RUNNER_JSON="["
+        runner_first=1
+        IFS=',' read -ra runner_labels <<< "$CI_RUNNER"
+        for label in "${runner_labels[@]}"; do
+          label="${label#"${label%%[![:space:]]*}"}"
+          label="${label%"${label##*[![:space:]]}"}"
+          [[ -z "$label" ]] && continue
+          if [[ "$runner_first" -eq 1 ]]; then runner_first=0; else RUNNER_JSON+=","; fi
+          RUNNER_JSON+="\"$label\""
+        done
+        # An all-blank value (e.g. DEVKIT_CI_RUNNER=" ,") falls back to the default.
+        [[ "$runner_first" -eq 1 ]] && RUNNER_JSON+="\"ubuntu-24.04\""
+        RUNNER_JSON+="]"
+        echo "runner-json=$RUNNER_JSON" >> "$GITHUB_OUTPUT"
 
         # Resolve the version tag: explicit override wins, else DEVKIT_VERSION,
         # else the legacy DEVCONTAINER_VERSION.

--- a/.github/actions/setup-devkit-toolchain/action.yml
+++ b/.github/actions/setup-devkit-toolchain/action.yml
@@ -149,6 +149,72 @@ runs:
             echo "UV_PYTHON_DOWNLOADS_JSON_URL=$UV_DL_JSON_URL" >> "$GITHUB_ENV"
           fi
         fi
+
+        # ── Forward the dev-shell's shellHook environment (#1180) ────────────
+        # GITHUB_PATH carries PATH only, so every env var a project exports from
+        # its flake `shellHook` (tool config, sensible defaults) — present in
+        # every local `nix develop`/direnv session — silently vanished on CI
+        # (vig-os/org-config#40: a shellHook-seeded OTTERDOG_TOKEN placeholder
+        # worked locally, failed on CI). Diff the ambient environment against the
+        # dev-shell environment (the shellHook has run inside `nix develop`) and
+        # forward the vars the dev-shell adds or changes, minus a denylist of
+        # shell session state and Nix/stdenv build machinery that must never leak
+        # into the CI environment. The diff is what keeps ambient host secrets
+        # (already in the runner env, unchanged inside the shell) out of
+        # GITHUB_ENV. Null-delimited dumps + a random GITHUB_ENV heredoc
+        # delimiter keep multi-line and special-character values intact.
+        env -0 > "$RUNNER_TEMP/devkit-host-env"
+        nix develop --profile "$RUNNER_TEMP/devkit-dev-profile" \
+          --command env -0 > "$RUNNER_TEMP/devkit-devshell-env"
+
+        # Denylist: shell session state (must never override the CI shell) and
+        # Nix/stdenv build machinery (PATH is already handled via GITHUB_PATH).
+        devkit_env_denied() {
+          case "$1" in
+            PATH|HOME|USER|LOGNAME|SHELL|TERM|PWD|OLDPWD|SHLVL|IFS|_) return 0 ;;
+            TMPDIR|TMP|TEMP|TEMPDIR) return 0 ;;
+            NIX_*) return 0 ;;
+            out|outputs|src|stdenv|system|builder|name|pname|version|shell|shellHook) return 0 ;;
+            buildInputs|nativeBuildInputs|propagatedBuildInputs|propagatedNativeBuildInputs) return 0 ;;
+            deps*|*Phase|phases|dont*) return 0 ;;
+            configureFlags|cmakeFlags|mesonFlags|makeFlags|patches|strictDeps|enableParallelBuilding) return 0 ;;
+            SOURCE_DATE_EPOCH|HOST_PATH|__structuredAttrs|outputHash*|preferLocalBuild|allowSubstitutes|cmakeDir) return 0 ;;
+            *) return 1 ;;
+          esac
+        }
+
+        # Ambient environment, keyed by name, to detect unchanged vars.
+        declare -A DEVKIT_HOST_ENV=()
+        while IFS= read -r -d '' devkit_kv; do
+          DEVKIT_HOST_ENV["${devkit_kv%%=*}"]="${devkit_kv#*=}"
+        done < "$RUNNER_TEMP/devkit-host-env"
+
+        devkit_env_forwarded=0
+        while IFS= read -r -d '' devkit_kv; do
+          devkit_name="${devkit_kv%%=*}"
+          devkit_value="${devkit_kv#*=}"
+          # Skip vars unchanged from the ambient environment (already present in
+          # the CI env; forwarding them would needlessly re-emit host secrets).
+          if [[ -n "${DEVKIT_HOST_ENV[$devkit_name]+x}" \
+                && "${DEVKIT_HOST_ENV[$devkit_name]}" == "$devkit_value" ]]; then
+            continue
+          fi
+          if devkit_env_denied "$devkit_name"; then
+            continue
+          fi
+          # Random heredoc delimiter: multi-line and special-character values
+          # survive intact and cannot break GITHUB_ENV parsing (GitHub's own
+          # multiline idiom).
+          devkit_delim="DEVKIT_ENV_EOF_${RANDOM}${RANDOM}${RANDOM}${RANDOM}"
+          {
+            printf '%s<<%s\n' "$devkit_name" "$devkit_delim"
+            printf '%s\n' "$devkit_value"
+            printf '%s\n' "$devkit_delim"
+          } >> "$GITHUB_ENV"
+          devkit_env_forwarded=$((devkit_env_forwarded + 1))
+        done < "$RUNNER_TEMP/devkit-devshell-env"
+        echo "Forwarded $devkit_env_forwarded dev-shell shellHook env var(s) to GITHUB_ENV."
+
         echo "Repo flake dev-shell provisioned; tools added to PATH."
 
     - name: Verify toolchain (prek present in dev-shell)

--- a/.github/actions/setup-devkit-toolchain/action.yml
+++ b/.github/actions/setup-devkit-toolchain/action.yml
@@ -96,7 +96,10 @@ runs:
           echo "has-nix=true" >> "$GITHUB_OUTPUT"
           # Some multi-user host Nix wrappers print --version to stderr (#1198);
           # fold it into the capture so the log keeps the version, not empty ().
-          echo "Host Nix present: $(command -v nix) ($(nix --version 2>&1))"
+          # Scrub the ambient NIX_CONFIG (#1216): a self-hosted runner's service
+          # env may carry a malformed one that makes nix error on the config
+          # before printing the version, defeating the diagnostic.
+          echo "Host Nix present: $(command -v nix) ($(env -u NIX_CONFIG nix --version 2>&1))"
         else
           echo "has-nix=false" >> "$GITHUB_OUTPUT"
         fi

--- a/.github/actions/setup-devkit-toolchain/action.yml
+++ b/.github/actions/setup-devkit-toolchain/action.yml
@@ -164,8 +164,12 @@ runs:
         # GITHUB_ENV. Null-delimited dumps + a random GITHUB_ENV heredoc
         # delimiter keep multi-line and special-character values intact.
         env -0 > "$RUNNER_TEMP/devkit-host-env"
+        # Dump the dev-shell env to a file INSIDE the shell command: capturing
+        # `nix develop` stdout would also capture shellHook output (the
+        # scaffolded flake echoes a banner), gluing it onto the first NUL
+        # record and corrupting GITHUB_ENV (#1189).
         nix develop --profile "$RUNNER_TEMP/devkit-dev-profile" \
-          --command env -0 > "$RUNNER_TEMP/devkit-devshell-env"
+          --command bash -c 'env -0 > "$1"' _ "$RUNNER_TEMP/devkit-devshell-env"
 
         # Denylist: shell session state (must never override the CI shell) and
         # Nix/stdenv build machinery (PATH is already handled via GITHUB_PATH).
@@ -193,6 +197,13 @@ runs:
         while IFS= read -r -d '' devkit_kv; do
           devkit_name="${devkit_kv%%=*}"
           devkit_value="${devkit_kv#*=}"
+          # A name that is not a valid env identifier can only come from a
+          # corrupted dump record; skip it rather than poisoning GITHUB_ENV
+          # (#1189).
+          if [[ ! "$devkit_name" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+            echo "::warning::Skipping malformed dev-shell env record name."
+            continue
+          fi
           # Skip vars unchanged from the ambient environment (already present in
           # the CI env; forwarding them would needlessly re-emit host secrets).
           if [[ -n "${DEVKIT_HOST_ENV[$devkit_name]+x}" \

--- a/.github/actions/setup-devkit-toolchain/action.yml
+++ b/.github/actions/setup-devkit-toolchain/action.yml
@@ -83,12 +83,31 @@ runs:
         echo "prek present: $(command -v prek)"
 
     # ── direnv — host, provision from the repo's own Nix flake dev-shell ──────
+    # Self-hosted runners (DEVKIT_CI_RUNNER, #1173) usually ship their own Nix;
+    # install-nix-action would abort on them and leave NIX_CONFIG malformed
+    # (#1192), so detect first and take the matching path below.
+    - name: Detect host Nix
+      if: inputs.mode == 'direnv'
+      id: detect-nix
+      shell: bash
+      run: |
+        set -euo pipefail
+        if command -v nix >/dev/null 2>&1; then
+          echo "has-nix=true" >> "$GITHUB_OUTPUT"
+          # Some multi-user host Nix wrappers print --version to stderr (#1198);
+          # fold it into the capture so the log keeps the version, not empty ().
+          echo "Host Nix present: $(command -v nix) ($(nix --version 2>&1))"
+        else
+          echo "has-nix=false" >> "$GITHUB_OUTPUT"
+        fi
+
     # Nix installer SHA-pinned to match the vig-os toolchain. The vig-os public
     # Cachix substituter (pull-only, no token) makes the dev-shell a fast
     # binary-cache pull; accept-flake-config lets the pinned vigos input
-    # contribute its own substituters.
+    # contribute its own substituters. Keep extra_nix_config in lockstep with
+    # the "Configure host Nix" step below (enforced by test).
     - name: Install Nix (upstream CppNix)
-      if: inputs.mode == 'direnv'
+      if: inputs.mode == 'direnv' && steps.detect-nix.outputs.has-nix != 'true'
       uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342  # v31.11.0
       with:
         extra_nix_config: |
@@ -96,6 +115,26 @@ runs:
           accept-flake-config = true
           extra-substituters = https://vig-os.cachix.org
           extra-trusted-public-keys = vig-os.cachix.org-1:yoOYRi3bvnM6ThxO0joLt7vtzhTfkq3r6jykeUMg7Bk=
+
+    # Preinstalled host Nix: export the same settings via a well-formed
+    # multi-line NIX_CONFIG instead of installing. On a multi-user host Nix
+    # the substituter entries may be ignored for non-trusted users — Cachix is
+    # an optimization, correctness does not depend on it. Keep the settings in
+    # lockstep with extra_nix_config above (enforced by test).
+    - name: Configure host Nix
+      if: inputs.mode == 'direnv' && steps.detect-nix.outputs.has-nix == 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        {
+          echo 'NIX_CONFIG<<DEVKIT_NIX_CONFIG_EOF'
+          echo 'experimental-features = nix-command flakes'
+          echo 'accept-flake-config = true'
+          echo 'extra-substituters = https://vig-os.cachix.org'
+          echo 'extra-trusted-public-keys = vig-os.cachix.org-1:yoOYRi3bvnM6ThxO0joLt7vtzhTfkq3r6jykeUMg7Bk='
+          echo 'DEVKIT_NIX_CONFIG_EOF'
+        } >> "$GITHUB_ENV"
+        echo "Configured preinstalled host Nix via NIX_CONFIG."
 
     # Optional: push this repo's own closure to a consumer-owned Cachix cache.
     # Skipped unless the repo passes cachix-cache; pulls need no token, so the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,16 @@
 # This collapses the former per-mode ci.yml overlays (container / direnv / bare)
 # into a single managed file (#991).
 #
+# Runner selection (#1173): `resolve-toolchain` also emits `runner-json`, a JSON
+# array of runner labels from the optional `.vig-os` key `DEVKIT_CI_RUNNER`
+# (comma-separated; absent => the hosted default). The toolchain jobs (lint,
+# test, commit-checks) and the summary gate declare
+# `runs-on: ${{ fromJSON(needs.resolve-toolchain.outputs.runner-json) }}`, so a
+# self-hosted consumer routes them onto its own runners without hand-editing this
+# managed file. `resolve-toolchain` itself stays on the hosted default (it
+# produces the output — chicken-and-egg); `dependency-review` stays hosted too
+# (public-repo-only, toolchain-free, and reads GitHub's dependency-graph API).
+#
 # Jobs:
 #   1. resolve-toolchain — Resolve delivery mode + image from .vig-os
 #   2. lint              — Pre-commit hooks
@@ -69,11 +79,13 @@ jobs:
       mode: ${{ steps.resolve.outputs.mode }}
       image: ${{ steps.resolve.outputs.image }}
       image-tag: ${{ steps.resolve.outputs.image-tag }}
+      runner-json: ${{ steps.resolve.outputs.runner-json }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          persist-credentials: false
           sparse-checkout: |
             .vig-os
             .github/actions/resolve-toolchain
@@ -90,7 +102,7 @@ jobs:
   lint:
     name: Lint & Format
     needs: [resolve-toolchain]
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(needs.resolve-toolchain.outputs.runner-json) }}
     # Empty image (direnv/bare) => runs on the host; non-empty => in-container.
     # The credentials block is inert on the host (proven by the #992 spike).
     container:
@@ -107,6 +119,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       # Mode-aware preamble: exports the in-image env + prek skew guard in
       # container mode, provisions the Nix dev-shell (direnv) or the uv host
@@ -128,7 +142,7 @@ jobs:
   test:
     name: Tests
     needs: [resolve-toolchain]
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(needs.resolve-toolchain.outputs.runner-json) }}
     container:
       image: ${{ needs.resolve-toolchain.outputs.image }}
       credentials:
@@ -143,6 +157,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up devkit toolchain
         uses: ./.github/actions/setup-devkit-toolchain
@@ -166,7 +182,7 @@ jobs:
   commit-checks:
     name: Commit Messages
     needs: [resolve-toolchain]
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(needs.resolve-toolchain.outputs.runner-json) }}
     container:
       image: ${{ needs.resolve-toolchain.outputs.image }}
       credentials:
@@ -244,6 +260,11 @@ jobs:
   # API is unavailable on Free-plan private repos, so private repos get a
   # skipped (neutral) run instead of a permanently red one, and a repo later
   # flipped public starts gating automatically with no re-scaffold (#1039).
+  #
+  # First run on a NEW public repo returns 403 if the org disables the dependency
+  # graph for new repos (dependency_graph_enabled_for_new_repositories: false).
+  # Enable it once (repo admin), the same toggle as Settings > Security >
+  # Dependency graph: gh api -X PUT repos/OWNER/REPO/vulnerability-alerts (#1166).
   dependency-review:
     name: Dependency Review
     runs-on: ubuntu-24.04
@@ -256,6 +277,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Review dependencies for vulnerabilities
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294  # v5.0.0
@@ -264,7 +287,7 @@ jobs:
 
   summary:
     name: CI Summary
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(needs.resolve-toolchain.outputs.runner-json) }}
     timeout-minutes: 5
     needs: [resolve-toolchain, lint, test, commit-checks, dependency-review]
     if: always()

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -76,6 +76,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a  # v4

--- a/.github/workflows/renovate-changelog-build.yml
+++ b/.github/workflows/renovate-changelog-build.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.base.ref }}
           sparse-checkout: |
             .vig-os

--- a/.github/workflows/sync-issues.yml
+++ b/.github/workflows/sync-issues.yml
@@ -56,6 +56,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          persist-credentials: false
           sparse-checkout: |
             .vig-os
             .github/actions/resolve-toolchain

--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -204,13 +204,14 @@ jobs:
         if: steps.recheck.outputs.up_to_date != 'true'
         env:
           GH_TOKEN: ${{ steps.commit-app-token.outputs.token }}
+          RELEASE_GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
         run: |
           set -euo pipefail
           REFS=$(retry --retries 3 --backoff 5 --max-backoff 30 -- \
             gh api --paginate "repos/${{ github.repository }}/git/matching-refs/heads/chore/sync-main-to-dev-" \
             --jq '.[].ref' | sed 's|refs/heads/||') || true
           for branch in ${REFS}; do
-            HAS_PR=$(GH_TOKEN="${{ steps.release-app-token.outputs.token }}" retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            HAS_PR=$(GH_TOKEN="${RELEASE_GH_TOKEN}" retry --retries 3 --backoff 5 --max-backoff 30 -- \
               gh pr list --base dev --head "${branch}" \
               --state open --json number --jq 'length')
             if [ "${HAS_PR}" = "0" ]; then

--- a/.vig-os
+++ b/.vig-os
@@ -7,7 +7,7 @@
 
 # Scaffold/image version pin (managed by release automation). Readers also
 # accept the legacy DEVCONTAINER_VERSION key for un-migrated consumers (#781).
-DEVKIT_VERSION=1.4.0-rc5
+DEVKIT_VERSION=1.4.0-rc6
 
 # Delivery mode: devcontainer | direnv | both | bare. Ships empty (= unset:
 # resolved and written back on scaffold) so an aborted upgrade can never

--- a/.vig-os
+++ b/.vig-os
@@ -7,7 +7,7 @@
 
 # Scaffold/image version pin (managed by release automation). Readers also
 # accept the legacy DEVCONTAINER_VERSION key for un-migrated consumers (#781).
-DEVKIT_VERSION=1.4.0-rc6
+DEVKIT_VERSION=1.4.0
 
 # Delivery mode: devcontainer | direnv | both | bare. Ships empty (= unset:
 # resolved and written back on scaffold) so an aborted upgrade can never

--- a/.vig-os
+++ b/.vig-os
@@ -7,7 +7,7 @@
 
 # Scaffold/image version pin (managed by release automation). Readers also
 # accept the legacy DEVCONTAINER_VERSION key for un-migrated consumers (#781).
-DEVKIT_VERSION=1.4.0-rc2
+DEVKIT_VERSION=1.4.0-rc3
 
 # Delivery mode: devcontainer | direnv | both | bare. Ships empty (= unset:
 # resolved and written back on scaffold) so an aborted upgrade can never

--- a/.vig-os
+++ b/.vig-os
@@ -7,7 +7,7 @@
 
 # Scaffold/image version pin (managed by release automation). Readers also
 # accept the legacy DEVCONTAINER_VERSION key for un-migrated consumers (#781).
-DEVKIT_VERSION=1.3.1
+DEVKIT_VERSION=1.4.0-rc2
 
 # Delivery mode: devcontainer | direnv | both | bare. Ships empty (= unset:
 # resolved and written back on scaffold) so an aborted upgrade can never
@@ -36,3 +36,11 @@ DEVKIT_TAG_PREFIX=v
 # `major,minor` moves <prefix>X and <prefix>X.Y so consumers can pin
 # `uses: owner/repo@v0`. Composes with DEVKIT_TAG_PREFIX; final releases only (#1045).
 DEVKIT_FLOATING_TAGS=major,minor
+
+# CI runner labels for the scaffolded ci.yml toolchain jobs (lint, test,
+# commit-checks) and the summary gate — comma-separated, e.g.
+# `self-hosted,linux,x64,meatgrinder`. Empty (default) => the hosted `ubuntu-24.04`
+# runner (no change for existing consumers). Routed into `runs-on` via
+# resolve-toolchain's `runner-json` output; the resolve-toolchain and
+# dependency-review jobs always stay on the hosted default (#1173).
+DEVKIT_CI_RUNNER=

--- a/.vig-os
+++ b/.vig-os
@@ -7,12 +7,22 @@
 
 # Scaffold/image version pin (managed by release automation). Readers also
 # accept the legacy DEVCONTAINER_VERSION key for un-migrated consumers (#781).
-DEVKIT_VERSION=1.4.0-rc3
+DEVKIT_VERSION=1.4.0-rc5
 
 # Delivery mode: devcontainer | direnv | both | bare. Ships empty (= unset:
 # resolved and written back on scaffold) so an aborted upgrade can never
 # persist a mode this repo did not choose.
 DEVKIT_MODE=direnv
+
+# Workflow model: gitflow (default) | trunk. Empty (= unset) resolves to the
+# gitflow default — long-lived `dev` + `main` with sync-main-to-dev.yml, no
+# change for devkit or existing consumers. `trunk` opts a repo into a
+# trunk-based flow: feature/bugfix/chore branches merge straight to `main`,
+# releases fork release/X.Y.Z from main and merge back into main, and the `dev`
+# branch and sync-main-to-dev.yml disappear. Realized entirely at scaffold time
+# (an anchored dev->main render + a sync-main-to-dev copy-exclude), mirroring
+# DEVKIT_MODE. Written back only for trunk, so a gitflow .vig-os is unchanged (#1205).
+DEVKIT_WORKFLOW=
 
 # Project identity (persisted SHORT_NAME / ORG_NAME / GITHUB_REPOSITORY);
 # written back by init-workspace.sh — edit only to deliberately rename.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Adopt vigOS devkit 1.4.0** ([#142](https://github.com/vig-os/sync-issues-action/issues/142))
+  - Re-scaffold from devkit 1.3.1 to 1.4.0 (direnv mode); pin the `vigos` flake input to `?ref=1.4.0` and re-lock `flake.lock`
+  - Managed workflows adopt the devkit-owned `zizmor` security baseline (new `zizmor.yml`) and its upstream fixes: `persist-credentials: false` on the read-only checkouts (`ci.yml` resolve/lint/test/dependency-review, `codeql.yml`, `renovate-changelog-build.yml`, `sync-issues.yml`) and the `sync-main-to-dev.yml` template-injection fix (release-app token moved to step `env:`) ([vig-os/devkit#1182](https://github.com/vig-os/devkit/issues/1182))
+  - Managed `ci.yml` toolchain jobs (`lint`, `test`, `commit-checks`, `summary`) route `runs-on` through the new `resolve-toolchain` `runner-json` output driven by the optional `.vig-os` `DEVKIT_CI_RUNNER` key; absent here, so the jobs keep `ubuntu-24.04` ([vig-os/devkit#1173](https://github.com/vig-os/devkit/issues/1173))
+  - direnv CI toolchain now forwards the flake `shellHook` environment to `GITHUB_ENV` ([vig-os/devkit#1180](https://github.com/vig-os/devkit/issues/1180)) and the base `justfile` ships a `with-native-libs` recipe for uvx native wheels ([vig-os/devkit#1181](https://github.com/vig-os/devkit/issues/1181))
 - **Adopt vigOS devkit 1.3.1** ([#138](https://github.com/vig-os/sync-issues-action/issues/138))
   - Re-scaffold from devkit 1.3.0 to 1.3.1 (direnv mode); pin the `vigos` flake input to `?ref=1.3.1` and re-lock `flake.lock` (previously floated on the devkit default branch)
   - CodeQL push-to-main `paths:` filter now renders the Node globs natively (`**.ts`, `**.js`, `**.mjs`, `**.cjs`, `.github/workflows/**`), retiring the hand patch ([vig-os/devkit#1142](https://github.com/vig-os/devkit/issues/1142))

--- a/docs/DOWNSTREAM_RELEASE.md
+++ b/docs/DOWNSTREAM_RELEASE.md
@@ -41,12 +41,36 @@ After final `release.yml` has pushed tag `X.Y.Z` and created a **draft** GitHub 
 
 1. **Validate** — semver, draft release for `X.Y.Z`, release PR not draft / approved / CI green
 2. **Promote** — `gh release edit --draft=false`
-3. **Merge** — merge `release/X.Y.Z` → `main` (triggers `sync-main-to-dev` when configured)
+3. **Merge** — merge `release/X.Y.Z` → `main` (triggers `sync-main-to-dev` under the gitflow model — see [Workflow models](#workflow-models))
 4. **Cleanup** (best-effort, does not fail the workflow) — delete remote git tags matching `${VERSION}-rc*` that have **no** GitHub Release
 
 **Upstream (`vig-os/devcontainer`) only:** Root `promote-release.yml` also prunes GHCR RC package versions via the org Packages API using **`GITHUB_TOKEN`** with **repo Admin** on the `devcontainer` package (one-time **Manage Actions access** grant). See [GitHub App Configuration](https://github.com/vig-os/devkit/blob/main/docs/RELEASE_CYCLE.md#github-app-configuration) and [Registry and cleanup tokens](https://github.com/vig-os/devkit/blob/main/docs/RELEASE_CYCLE.md#registry-and-cleanup-tokens-upstream) in `docs/RELEASE_CYCLE.md`.
 
 This template does **not** implement upstream-only steps (GHCR `:latest`, cosign, cross-repo smoke-test gate). Projects that need registry or deploy promotion after merge should run separate automation or extend their `release-extension.yml` / own workflows; see [Extension Hook](#extension-hook).
+
+## Workflow models
+
+The whole release flow above is the same under either **workflow model** a
+consumer selects with `DEVKIT_WORKFLOW` in `.vig-os` (`gitflow`, the default, or
+`trunk` — [#1205](https://github.com/vig-os/devkit/issues/1205)): `release/X.Y.Z`
+is still cut, driven through the RC train, finalized, and merged. The models
+differ only in the base the release branch forks from and merges back to, which
+is settled entirely at scaffold time (an anchored `dev -> main` render — see
+[`docs/rfcs/ADR-workflow-model.md`](https://github.com/vig-os/devkit/blob/main/docs/rfcs/ADR-workflow-model.md)).
+One release step is model-dependent:
+
+- **`sync-main-to-dev.yml` runs only under `gitflow`.** The gitflow model keeps a
+  long-lived `dev` integration branch, so a push to `main` (including a release
+  merge) opens a PR syncing `main` back into `dev`. The `trunk` model has no
+  `dev` branch — `feature`/`bugfix`/`chore` branches merge straight to `main` and
+  `release/X.Y.Z` merges back into `main` — so `sync-main-to-dev.yml` is never
+  scaffolded (copy-excluded, and pruned on a gitflow → trunk upgrade). The
+  promote-time back-merge referenced above is therefore a no-op under `trunk`.
+
+Consumer-facing opt-in, the destructive-switch preflight, and the orphan `dev`
+cleanup caveat are documented in
+[`docs/MIGRATION.md`](https://github.com/vig-os/devkit/blob/main/docs/MIGRATION.md#workflow-models); the branching topology in
+[`docs/RELEASE_CYCLE.md`](https://github.com/vig-os/devkit/blob/main/docs/RELEASE_CYCLE.md#workflow-models).
 
 ## Workflow Interface
 

--- a/flake.lock
+++ b/flake.lock
@@ -224,16 +224,16 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1784272477,
-        "narHash": "sha256-4e67ct6uvGBBtdagM0sbUsTlD1QYIJ1HXsEcmqIitCE=",
+        "lastModified": 1784296780,
+        "narHash": "sha256-NrpiZU6bLh4h5nqy2LAdYmsOhD6w9Vo7guw4ZvkxYz0=",
         "owner": "vig-os",
         "repo": "devkit",
-        "rev": "5cfbac3038882cd124e7490271e26bc6490a271a",
+        "rev": "6fe5f7704cc4d9d7894ff003ecdbd77746bf6ec7",
         "type": "github"
       },
       "original": {
         "owner": "vig-os",
-        "ref": "1.3.1",
+        "ref": "1.4.0-rc2",
         "repo": "devkit",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -224,16 +224,16 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1784301414,
-        "narHash": "sha256-XOSvTfeWSLtvn6UVWv/DGDeJGOwlK1Whxx7mk+S4v5w=",
+        "lastModified": 1784537507,
+        "narHash": "sha256-EiwGwhKrymeLz7tSoZpe5hSEntOiYWWmMLreObVr/bM=",
         "owner": "vig-os",
         "repo": "devkit",
-        "rev": "b533ef9819d69fe3b98d7e9f61c9f1eeb49a936e",
+        "rev": "5851a6a23908b1eeead4e6b6d08b8c036d6ff534",
         "type": "github"
       },
       "original": {
         "owner": "vig-os",
-        "ref": "1.4.0-rc3",
+        "ref": "1.4.0-rc5",
         "repo": "devkit",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -119,11 +119,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1783816212,
-        "narHash": "sha256-2aZisVTVGSFEk3MYcOiWQp3zvwyzbqpktB69Rcfp150=",
+        "lastModified": 1784453100,
+        "narHash": "sha256-zpGZb8FYui+i8KLtC0nlcmb0voR2zB80Qn8pe7lzIbk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3b32825de172d0bc85664f495edb096b10862524",
+        "rev": "b471514bed69eff5255c8e63c1f80e5fe56c616f",
         "type": "github"
       },
       "original": {
@@ -224,16 +224,16 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1784537507,
-        "narHash": "sha256-EiwGwhKrymeLz7tSoZpe5hSEntOiYWWmMLreObVr/bM=",
+        "lastModified": 1784548411,
+        "narHash": "sha256-J5gdcj1PKzFvybLSr6G93WmbnflIjRB2QO3eKIULuIA=",
         "owner": "vig-os",
         "repo": "devkit",
-        "rev": "5851a6a23908b1eeead4e6b6d08b8c036d6ff534",
+        "rev": "af008a159843fdcd37b7b73f29235f232c553da9",
         "type": "github"
       },
       "original": {
         "owner": "vig-os",
-        "ref": "1.4.0-rc5",
+        "ref": "1.4.0-rc6",
         "repo": "devkit",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -224,16 +224,15 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1784548411,
-        "narHash": "sha256-J5gdcj1PKzFvybLSr6G93WmbnflIjRB2QO3eKIULuIA=",
+        "lastModified": 1784561107,
+        "narHash": "sha256-xIXQ5prcqVdLCcBDk+8q/NMWypN4Q2DZjl90A+f73ho=",
         "owner": "vig-os",
         "repo": "devkit",
-        "rev": "af008a159843fdcd37b7b73f29235f232c553da9",
+        "rev": "d16541f52fac305a1c08fc09a6c4596c2d54f457",
         "type": "github"
       },
       "original": {
         "owner": "vig-os",
-        "ref": "1.4.0-rc6",
         "repo": "devkit",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -224,16 +224,16 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1784296780,
-        "narHash": "sha256-NrpiZU6bLh4h5nqy2LAdYmsOhD6w9Vo7guw4ZvkxYz0=",
+        "lastModified": 1784301414,
+        "narHash": "sha256-XOSvTfeWSLtvn6UVWv/DGDeJGOwlK1Whxx7mk+S4v5w=",
         "owner": "vig-os",
         "repo": "devkit",
-        "rev": "6fe5f7704cc4d9d7894ff003ecdbd77746bf6ec7",
+        "rev": "b533ef9819d69fe3b98d7e9f61c9f1eeb49a936e",
         "type": "github"
       },
       "original": {
         "owner": "vig-os",
-        "ref": "1.4.0-rc2",
+        "ref": "1.4.0-rc3",
         "repo": "devkit",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
     #   vigos.url = "github:vig-os/devkit?ref=<tag>";
     # Policy: https://github.com/vig-os/devkit/blob/main/docs/NIX.md
     # "Home-manager modules - versioning & release policy".
-    vigos.url = "github:vig-os/devkit?ref=1.4.0-rc3";
+    vigos.url = "github:vig-os/devkit?ref=1.4.0-rc5";
     # Follow vigos's pinned nixpkgs + flake-utils so your tools match the
     # toolchain exactly (one resolved nixpkgs, no drift).
     nixpkgs.follows = "vigos/nixpkgs";

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
     #   vigos.url = "github:vig-os/devkit?ref=<tag>";
     # Policy: https://github.com/vig-os/devkit/blob/main/docs/NIX.md
     # "Home-manager modules - versioning & release policy".
-    vigos.url = "github:vig-os/devkit?ref=1.4.0-rc5";
+    vigos.url = "github:vig-os/devkit?ref=1.4.0-rc6";
     # Follow vigos's pinned nixpkgs + flake-utils so your tools match the
     # toolchain exactly (one resolved nixpkgs, no drift).
     nixpkgs.follows = "vigos/nixpkgs";

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
     #   vigos.url = "github:vig-os/devkit?ref=<tag>";
     # Policy: https://github.com/vig-os/devkit/blob/main/docs/NIX.md
     # "Home-manager modules - versioning & release policy".
-    vigos.url = "github:vig-os/devkit?ref=1.4.0-rc6";
+    vigos.url = "github:vig-os/devkit";
     # Follow vigos's pinned nixpkgs + flake-utils so your tools match the
     # toolchain exactly (one resolved nixpkgs, no drift).
     nixpkgs.follows = "vigos/nixpkgs";

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
     #   vigos.url = "github:vig-os/devkit?ref=<tag>";
     # Policy: https://github.com/vig-os/devkit/blob/main/docs/NIX.md
     # "Home-manager modules - versioning & release policy".
-    vigos.url = "github:vig-os/devkit?ref=1.4.0-rc2";
+    vigos.url = "github:vig-os/devkit?ref=1.4.0-rc3";
     # Follow vigos's pinned nixpkgs + flake-utils so your tools match the
     # toolchain exactly (one resolved nixpkgs, no drift).
     nixpkgs.follows = "vigos/nixpkgs";

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
     #   vigos.url = "github:vig-os/devkit?ref=<tag>";
     # Policy: https://github.com/vig-os/devkit/blob/main/docs/NIX.md
     # "Home-manager modules - versioning & release policy".
-    vigos.url = "github:vig-os/devkit?ref=1.3.1";
+    vigos.url = "github:vig-os/devkit?ref=1.4.0-rc2";
     # Follow vigos's pinned nixpkgs + flake-utils so your tools match the
     # toolchain exactly (one resolved nixpkgs, no drift).
     nixpkgs.follows = "vigos/nixpkgs";

--- a/justfile
+++ b/justfile
@@ -16,6 +16,35 @@ set shell := ["bash", "-euo", "pipefail", "-c"]
 help:
     @just --list
 
+# Run a command with libstdc++ resolvable for uvx-run native wheels (#1181).
+# On a non-Python direnv-mode consumer the CI preamble keeps the Nix CPython on
+# PATH, whose loader does not search /usr/lib, so a uvx tool's manylinux native
+# wheel (e.g. otterdog's rjsonnet) fails to import with
+# "libstdc++.so.6: cannot open shared object file". This wraps ONE command with
+# a command-scoped LD_LIBRARY_PATH sourced from $VIGOS_STDCPP_LIB (dev-shell
+# export) or derived from the on-PATH `cc` wrapper (cc echoes the bare name
+# back — not an absolute path — when it cannot resolve the lib, so the leading-/
+# check leaves the prefix empty). Scoping it to this one command keeps the Nix
+# libstdc++ out of every other tool's process. When nothing resolves, the
+# environment is left UNTOUCHED — never compose with an empty prefix, since an
+# empty LD_LIBRARY_PATH entry (leading colon, or a bare "") means "current
+# working directory" to the dynamic loader. Lives here (not justfile.devc,
+# devcontainer-only) so it is reachable in direnv/bare mode — the case that
+# needs it. Usage from a justfile.project recipe:
+# just with-native-libs uvx --from otterdog@1.2.3 otterdog validate --local
+[group('helpers')]
+with-native-libs +command:
+    @stdcpp_lib="${VIGOS_STDCPP_LIB:-}"; \
+    if [ -z "$stdcpp_lib" ] && command -v cc >/dev/null 2>&1; then \
+      p="$(cc -print-file-name=libstdc++.so.6)"; \
+      case "$p" in /*) stdcpp_lib="$(dirname "$p")" ;; esac; \
+    fi; \
+    if [ -n "$stdcpp_lib" ]; then \
+      LD_LIBRARY_PATH="$stdcpp_lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" {{ command }}; \
+    else \
+      {{ command }}; \
+    fi
+
 # Import devcontainer-managed base recipes (replaced on upgrade).
 # Optional: a `direnv`-mode workspace (`init-workspace --mode direnv`) has no
 # .devcontainer/, so these must not be hard imports or `just` fails to load.

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,0 +1,87 @@
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
+# zizmor configuration — GitHub Actions security auditing baseline.
+#
+# Devkit OWNS this baseline. It suppresses the residual zizmor findings in the
+# devkit-managed workflows that cannot be fixed without changing release/CI
+# behavior for every consumer. Devkit's own CI gates the managed workflow set
+# against this file (see .github/workflows/ci.yml → "Audit managed workflows"),
+# so a regression — a new finding, or a managed workflow that regains a fixed
+# finding — fails devkit CI and must be fixed or triaged here, not silently
+# baselined downstream.
+#
+# This file is SCAFFOLDED into every consumer repo (manifest entry: zizmor.yml)
+# so their baseline for devkit's output shrinks to zero: a consumer adopting
+# `zizmor` inherits exactly these exemptions and maintains none of their own for
+# managed files.
+#
+# SCOPE RULE (load-bearing): every entry is a SPECIFIC managed workflow
+# BASENAME, never a `*.yml` glob. A repo-authored (consumer-authored) workflow
+# has a different filename and therefore NEVER inherits a managed file's
+# exemption — its findings are always reported. When a devkit upgrade adds,
+# renames, or removes a managed workflow, or a new zizmor audit surfaces, update
+# this file as part of that upgrade (or fix the workflow upstream in
+# vig-os/devkit). Full policy:
+# https://github.com/vig-os/devkit/blob/main/docs/WORKFLOW_SECURITY.md
+#
+# Fixed upstream (NOT baselined — listed here as a record of what devkit fixed):
+#   - artipacked        → persist-credentials: false on read-only checkouts
+#                         (ci.yml lint/test/resolve/dependency-review, codeql.yml,
+#                         renovate-changelog-build.yml, sync-issues.yml resolve).
+#   - template-injection → release-app token moved into step env in
+#                         sync-main-to-dev.yml.
+#
+# Residual (baselined below), why each is intentional:
+#   - artipacked        → checkouts that push or fetch from a private remote and
+#                         therefore rely on the persisted git credential
+#                         (ci.yml commit-checks, all release/sync branch work).
+#   - dangerous-triggers → renovate-changelog-commit.yml runs on `workflow_run`
+#                         by design (it commits the built changelog).
+#   - github-app        → create-github-app-token intentionally mints a
+#                         broadly-scoped installation token for release
+#                         orchestration; per-permission scoping would break the
+#                         multi-repo release/sync flows.
+#   - secrets-inherit   → release.yml / prepare-release.yml fan out to reusable
+#                         workflows with `secrets: inherit` by design.
+#   - unpinned-images   → `image:` is the devkit toolchain image resolved at
+#                         runtime (needs.*.outputs.image / inputs.toolchain_image);
+#                         it cannot be SHA-pinned in source.
+rules:
+  artipacked:
+    ignore:
+      - ci.yml
+      - prepare-release.yml
+      - promote-release.yml
+      - release-core.yml
+      - release-publish.yml
+      - release.yml
+      - sync-main-to-dev.yml
+  dangerous-triggers:
+    ignore:
+      - renovate-changelog-commit.yml
+  github-app:
+    ignore:
+      - prepare-release.yml
+      - promote-release.yml
+      - release-core.yml
+      - release-publish.yml
+      - release.yml
+      - renovate-changelog-commit.yml
+      - sync-issues.yml
+      - sync-main-to-dev.yml
+  secrets-inherit:
+    ignore:
+      - prepare-release.yml
+      - release.yml
+  unpinned-images:
+    ignore:
+      - ci.yml
+      - prepare-release.yml
+      - promote-release.yml
+      - release-core.yml
+      - release-publish.yml
+      - release.yml
+      - renovate-changelog-build.yml
+      - sync-issues.yml
+      - sync-main-to-dev.yml


### PR DESCRIPTION
## Summary

Re-scaffolds this repo onto **vigOS devkit 1.4.0** (from 1.3.1, direnv mode).

> **RC validation:** the `vigos` flake input is pinned to **`?ref=1.4.0-rc2`** to
> validate the release ahead of the final `1.4.0` tag. This PR is the live
> consumer proof for the 1.4.0 release train; the pin is bumped to `?ref=1.4.0`
> (and `flake.lock` re-locked) before merge. **Do not merge while pinned to rc2.**

Refs: #142 · follows the 1.3.1 adoption (#139).

## Commits

1. `build(devkit): adopt vigOS devkit 1.4.0 in direnv mode` — installer
   re-scaffold + flake pin/lock + CHANGELOG.

## Managed-file deltas (all rendered by `init-workspace.sh`)

- **zizmor baseline** ([vig-os/devkit#1182](https://github.com/vig-os/devkit/issues/1182)) — new managed `zizmor.yml` (devkit-owned baseline; every entry scoped to a managed-workflow basename, so a consumer-authored workflow never inherits an exemption) plus the upstream fixes: `persist-credentials: false` on the read-only checkouts (`ci.yml` resolve/lint/test/dependency-review, `codeql.yml`, `renovate-changelog-build.yml`, `sync-issues.yml`) and the `sync-main-to-dev.yml` `template-injection` fix (release-app token moved into step `env:`). Behavior-preserving. `zizmor` is not in this repo's flake hook set or CI, so the baseline ships as an inert config file here.
- **CI runner knob** ([vig-os/devkit#1173](https://github.com/vig-os/devkit/issues/1173)) — `resolve-toolchain` emits a new `runner-json` output from the optional `.vig-os` `DEVKIT_CI_RUNNER` key; `ci.yml` toolchain jobs (`lint`, `test`, `commit-checks`, `summary`) resolve `runs-on: ${{ fromJSON(...) }}`. The key is **absent** here, so `runner-json` defaults to `["ubuntu-24.04"]` — no runner change.
- **direnv CI shellHook env forward** ([vig-os/devkit#1180](https://github.com/vig-os/devkit/issues/1180)) — `setup-devkit-toolchain` now diffs the dev-shell env and forwards `shellHook` vars to `GITHUB_ENV`.
- **`with-native-libs` recipe** ([vig-os/devkit#1181](https://github.com/vig-os/devkit/issues/1181)) — base `justfile` gains a helper wrapping a command with a scoped `LD_LIBRARY_PATH` for uvx native wheels.

## Fix-signature evidence

- **Flake pin bumped + re-locked** — `flake.nix` now `vigos.url = "github:vig-os/devkit?ref=1.4.0-rc2"`; `flake.lock` `vigos` re-locked to rev `6fe5f770` (= the `1.4.0-rc2` tag commit) with `original.ref = "1.4.0-rc2"`. Follows-inputs (nixpkgs/flake-utils) unchanged. `.vig-os` `DEVKIT_VERSION=1.4.0-rc2`, `DEVKIT_MODE=direnv`, `DEVKIT_TAG_PREFIX=v`, `DEVKIT_FLOATING_TAGS=major,minor` preserved; new `DEVKIT_CI_RUNNER=` (empty) added.

## Landmines preserved

- **`release-extension.yml` untouched** — the build-provenance **attestation seam** migrated in #139 (final-release `attest` job) and the `verify-dist` backstop both survive byte-for-byte (not in the diff; it is consumer-owned, not a managed file).
- **Integration-test matrix untouched** — `integration-*.yml`, `js-quality.yml`, `published-tag-smoke.yml`, `prepare-release-extension.yml` are consumer-owned and unchanged.
- **`justfile.project`, `.envrc`, `flake.nix` customizations preserved** — `hooksExcludes = [ "^dist/" ]` and `extraPackages` kept; only the base `justfile` (managed) changed.

## Verification

- `direnv exec . just precommit` — **full suite green** (dev-shell rebuilt on the 1.4.0-rc2 toolchain; `pymarkdown` now runs as the flake `language: system` hook per [vig-os/devkit#1170](https://github.com/vig-os/devkit/issues/1170), the nix hooks `deadnix`/`statix`/`nixfmt` per [vig-os/devkit#1171](https://github.com/vig-os/devkit/issues/1171)).
- `direnv exec . npm test` — **138/138 jest tests pass**.

## Notes for the reviewer

- **CODEOWNERS**: the re-scaffold re-seeded an inert (fully commented) `.github/CODEOWNERS` placeholder; removed to honor the deliberate removal in #106/#139 (net-zero git change).
- **`.pre-commit-config.yaml` scaffold quirk (worktree-order, not a devkit defect)**: scaffolding into a fresh worktree *before* the direnv dev-shell had been loaded meant the flake-generated `/nix/store` symlink did not yet exist, so `init-workspace.sh` (which treats `.pre-commit-config.yaml` as a *preserved* file) saw it absent and copied the hand-managed template. The new direnv flake-hooks opt-in guard ([#1167](https://github.com/vig-os/devkit/issues/1167)) then correctly refused to clobber it. Resolved exactly as the guard instructs (remove the gitignored file → flake regenerates the symlink), yielding the same flake-generated `.pre-commit-config.yaml` symlink the 1.3.1 checkout carries. The gitignored file is not part of this PR.
- Do **not** merge — CODEOWNERS/review gate; left ready + green. Bump rc2 → final `1.4.0` before merge.
