### PR TITLE
chore: adopt devkit 1.4.1

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Seeded by vigOS devkit — yours to edit; upgrades never overwrite this file.
+# Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
+# CODEOWNERS — default reviewers for pull requests
+# Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# Each line defines a file pattern and the GitHub users/teams required to review
+# changes to matching files. Later rules take precedence over earlier ones.
+
+# Default: all files require review from the maintainer
+#*                               @username

--- a/.github/label-taxonomy.toml
+++ b/.github/label-taxonomy.toml
@@ -13,6 +13,13 @@
 #   The `setup-labels` command is provided by devcontainer bootstrap tooling.
 #   from this taxonomy. Use `--prune` to remove org-default labels that don't
 #   match the taxonomy. Use `--dry-run` to preview changes first.
+#
+# Repo-local extension:
+#   Declare repo-specific labels in `.github/label-taxonomy.local.toml` (same
+#   [[labels]] schema). That file is never devkit-managed — it survives
+#   upgrades, its labels are reconciled and spared by `--prune`, and on a name
+#   collision the local entry wins (mirrors the justfile.base -> justfile.local
+#   layering).
 
 # ── Type ──────────────────────────────────────────────────────────────────────
 

--- a/.vig-os
+++ b/.vig-os
@@ -7,7 +7,7 @@
 
 # Scaffold/image version pin (managed by release automation). Readers also
 # accept the legacy DEVCONTAINER_VERSION key for un-migrated consumers (#781).
-DEVKIT_VERSION=1.4.1-rc3
+DEVKIT_VERSION=1.4.1-rc4
 
 # Delivery mode: devcontainer | direnv | both | bare. Ships empty (= unset:
 # resolved and written back on scaffold) so an aborted upgrade can never

--- a/.vig-os
+++ b/.vig-os
@@ -7,7 +7,7 @@
 
 # Scaffold/image version pin (managed by release automation). Readers also
 # accept the legacy DEVCONTAINER_VERSION key for un-migrated consumers (#781).
-DEVKIT_VERSION=1.4.1-rc4
+DEVKIT_VERSION=1.4.1
 
 # Delivery mode: devcontainer | direnv | both | bare. Ships empty (= unset:
 # resolved and written back on scaffold) so an aborted upgrade can never

--- a/.vig-os
+++ b/.vig-os
@@ -7,7 +7,7 @@
 
 # Scaffold/image version pin (managed by release automation). Readers also
 # accept the legacy DEVCONTAINER_VERSION key for un-migrated consumers (#781).
-DEVKIT_VERSION=1.4.1-rc2
+DEVKIT_VERSION=1.4.1-rc3
 
 # Delivery mode: devcontainer | direnv | both | bare. Ships empty (= unset:
 # resolved and written back on scaffold) so an aborted upgrade can never

--- a/.vig-os
+++ b/.vig-os
@@ -7,7 +7,7 @@
 
 # Scaffold/image version pin (managed by release automation). Readers also
 # accept the legacy DEVCONTAINER_VERSION key for un-migrated consumers (#781).
-DEVKIT_VERSION=1.4.0
+DEVKIT_VERSION=1.4.1-rc2
 
 # Delivery mode: devcontainer | direnv | both | bare. Ships empty (= unset:
 # resolved and written back on scaffold) so an aborted upgrade can never
@@ -54,3 +54,18 @@ DEVKIT_FLOATING_TAGS=major,minor
 # resolve-toolchain's `runner-json` output; the resolve-toolchain and
 # dependency-review jobs always stay on the hosted default (#1173).
 DEVKIT_CI_RUNNER=
+
+# Branch the scaffolded sync-issues job commits to. Empty (default) resolves to
+# the workflow-model default — `dev` (gitflow) / `main` (trunk) — unchanged for
+# existing consumers. A repo whose `main` carries a require-PR ruleset (which
+# refuses the sync job's direct API push, #1227) sets a dedicated UNPROTECTED
+# mirror branch, e.g. `sync/issue-mirror`; the sync job bootstraps it from the
+# default branch head if absent. The mirror diverges permanently and is never
+# merged back — each sync run regenerates full state (#1228).
+DEVKIT_SYNC_TARGET=
+
+# Cron override for the sync-issues schedule trigger (5-field cron, validated at
+# scaffold time). Empty (default) => the daily `0 2 * * *`. e.g. `0 5 * * 0` runs
+# the sync weekly on Sundays. Realized at scaffold time because schedule triggers
+# cannot take inputs (#1228).
+DEVKIT_SYNC_SCHEDULE=


### PR DESCRIPTION
Adopts devkit **1.4.1** (final, [release](https://github.com/vig-os/devkit/releases/tag/1.4.1)).

Validated through the full 1.4.1 RC train (rc2 → rc3 → rc4, each bump re-scaffolded with the RC image and CI-green in this lane). Final scaffold diff vs 1.4.0: `.vig-os` version pin, the taxonomy header (devkit#1254), and the sync knobs (`DEVKIT_SYNC_TARGET`/`DEVKIT_SYNC_SCHEDULE`, devkit#1228) — all other managed files render unchanged.

Closes #144
Refs #144