### PR TITLE
chore: adopt devkit 1.4.2

### DIFF
--- a/.vig-os
+++ b/.vig-os
@@ -7,7 +7,7 @@
 
 # Scaffold/image version pin (managed by release automation). Readers also
 # accept the legacy DEVCONTAINER_VERSION key for un-migrated consumers (#781).
-DEVKIT_VERSION=1.4.1
+DEVKIT_VERSION=1.4.2
 
 # Delivery mode: devcontainer | direnv | both | bare. Ships empty (= unset:
 # resolved and written back on scaffold) so an aborted upgrade can never

--- a/flake.lock
+++ b/flake.lock
@@ -224,11 +224,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1784561107,
-        "narHash": "sha256-xIXQ5prcqVdLCcBDk+8q/NMWypN4Q2DZjl90A+f73ho=",
+        "lastModified": 1785079284,
+        "narHash": "sha256-22xlYj2gwUq1Cz8Ivz9H3Vs+nPYutevzQp5mLW6u31U=",
         "owner": "vig-os",
         "repo": "devkit",
-        "rev": "d16541f52fac305a1c08fc09a6c4596c2d54f457",
+        "rev": "b884b22bcb0b3ad1d192c1b5b4b4251c90202c23",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bump devkit pin to 1.4.2 (https://github.com/vig-os/devkit/releases/tag/1.4.2). vigos flake.lock advanced in lockstep (vig-os/devkit#1263): d16541f5 → b884b22b.

Closes #153