### PR TITLE
chore: adopt devkit 1.6.0

### DIFF
--- a/.github/actions/resolve-toolchain/action.yml
+++ b/.github/actions/resolve-toolchain/action.yml
@@ -50,6 +50,12 @@ outputs:
   image:
     description: Container image (ghcr.io/... for container modes, empty string for host modes)
     value: ${{ steps.resolve.outputs.image }}
+  drift-image:
+    description: >-
+      Devcontainer image ref for EVERY mode (empty only when no tag resolved),
+      for the scaffold-drift job that `docker run`s the scaffold on the host.
+      Keeps the ghcr.io/vig-os/devcontainer literal out of ci.yml (#1295).
+    value: ${{ steps.resolve.outputs.drift-image }}
   image-tag:
     description: Resolved image/version tag
     value: ${{ steps.resolve.outputs.tag }}
@@ -65,6 +71,18 @@ outputs:
       use with fromJSON() in `runs-on`. Defaults to ["ubuntu-24.04"] when the
       key is absent.
     value: ${{ steps.resolve.outputs.runner-json }}
+  refs-optional-types:
+    description: >-
+      Comma-separated commit types whose Refs line is optional, mapped from
+      DEVKIT_REFS_POLICY for validate-commit-range. `chore` (default/absent),
+      the full types list (`optional`), or the `none` sentinel (`required`).
+    value: ${{ steps.resolve.outputs.refs-optional-types }}
+  drift-check:
+    description: >-
+      Scaffold-drift gate toggle from DEVKIT_DRIFT_CHECK: `true` (default/absent)
+      keeps ci.yml's scaffold-drift job enabled, `false` self-skips it. Emitted
+      for every mode so the job's `if:` can gate on it with no re-scaffold.
+    value: ${{ steps.resolve.outputs.drift-check }}
 
 runs:
   using: composite
@@ -83,6 +101,8 @@ runs:
         TAG_PREFIX=""
         FLOATING_TAGS=""
         CI_RUNNER=""
+        REFS_POLICY=""
+        DRIFT_CHECK=""
 
         if [[ -f .vig-os ]]; then
           # Tolerant KEY=VALUE parsing shared with resolve-image (#781): capture
@@ -94,7 +114,7 @@ runs:
             [[ "$line" =~ ^[[:space:]]*# ]] && continue
 
             case "$line" in
-              DEVKIT_MODE=*|DEVKIT_VERSION=*|DEVCONTAINER_VERSION=*|DEVKIT_TAG_PREFIX=*|DEVKIT_FLOATING_TAGS=*|DEVKIT_CI_RUNNER=*)
+              DEVKIT_MODE=*|DEVKIT_VERSION=*|DEVCONTAINER_VERSION=*|DEVKIT_TAG_PREFIX=*|DEVKIT_FLOATING_TAGS=*|DEVKIT_CI_RUNNER=*|DEVKIT_REFS_POLICY=*|DEVKIT_DRIFT_CHECK=*)
                 key="${line%%=*}"
                 value="${line#*=}"
                 value="${value#"${value%%[![:space:]]*}"}"
@@ -113,6 +133,8 @@ runs:
                   DEVKIT_TAG_PREFIX) TAG_PREFIX="$value" ;;
                   DEVKIT_FLOATING_TAGS) FLOATING_TAGS="$value" ;;
                   DEVKIT_CI_RUNNER) CI_RUNNER="$value" ;;
+                  DEVKIT_REFS_POLICY) REFS_POLICY="$value" ;;
+                  DEVKIT_DRIFT_CHECK) DRIFT_CHECK="$value" ;;
                 esac
                 ;;
             esac
@@ -167,6 +189,33 @@ runs:
         RUNNER_JSON+="]"
         echo "runner-json=$RUNNER_JSON" >> "$GITHUB_OUTPUT"
 
+        # Refs policy (#1282): map DEVKIT_REFS_POLICY to the --refs-optional-types
+        # list validate-commit-range consumes in the commit-checks job. This is
+        # the single mapping point for the CI surface; it MIRRORS render_refs_policy
+        # in assets/init-workspace.sh (two renderers, one key — keep in lockstep).
+        # The loud enum guard lives at the write path (init-workspace.sh); here an
+        # unexpected/absent value defaults safely to `chore` (today's behavior) so
+        # CI never breaks on a surprise literal. `required` uses a `none` sentinel
+        # type (no real commit is type `none`) because an empty list is parsed as
+        # falsy by the tool and reverts to the {chore} default.
+        case "$REFS_POLICY" in
+          optional) REFS_OPTIONAL_TYPES="feat,fix,docs,chore,refactor,perf,test,ci,build,revert,style" ;;
+          required) REFS_OPTIONAL_TYPES="none" ;;
+          *)        REFS_OPTIONAL_TYPES="chore" ;;
+        esac
+        echo "refs-optional-types=$REFS_OPTIONAL_TYPES" >> "$GITHUB_OUTPUT"
+
+        # Scaffold-drift gate (#1295): DEVKIT_DRIFT_CHECK toggles ci.yml's
+        # scaffold-drift job. Absent/empty => `true` (enabled), so existing
+        # consumers gain the gate on adoption; only an explicit `false` disables
+        # it. Emitted for every mode; the loud value guard lives at the write path
+        # (init-workspace.sh), so any non-`false` literal here defaults to enabled
+        # (fail-safe: the drift check runs). The job self-skips on `false` via its
+        # `if:`, so flipping the knob needs no re-scaffold.
+        DRIFT_CHECK="${DRIFT_CHECK:-true}"
+        [[ "$DRIFT_CHECK" == "false" ]] || DRIFT_CHECK="true"
+        echo "drift-check=$DRIFT_CHECK" >> "$GITHUB_OUTPUT"
+
         # Resolve the version tag: explicit override wins, else DEVKIT_VERSION,
         # else the legacy DEVCONTAINER_VERSION.
         TAG="$INPUT_IMAGE_TAG"
@@ -193,6 +242,18 @@ runs:
             ;;
         esac
         echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
+
+        # Scaffold-drift image (#1295): the devcontainer image ref for EVERY mode
+        # (empty only when no tag resolved). Unlike `image` above — which is an
+        # explicit empty string for host modes so downstream `container:` runs on
+        # the host — the scaffold-drift job `docker run`s the image itself (the
+        # scaffold assets live only in the image, and a direnv/bare consumer's
+        # jobs otherwise never pull it). Emitting the ref here keeps the
+        # `ghcr.io/vig-os/devcontainer` literal out of the scaffolded ci.yml (the
+        # #991 single-source-of-truth invariant).
+        DRIFT_IMAGE=""
+        [[ -n "$TAG" ]] && DRIFT_IMAGE="ghcr.io/vig-os/devcontainer:${TAG}"
+        echo "drift-image=$DRIFT_IMAGE" >> "$GITHUB_OUTPUT"
         echo "Resolved mode=$MODE tag=${TAG:-<none>} image=${IMAGE:-<host>}"
 
     - name: Validate image accessibility

--- a/.github/renovate-default.json
+++ b/.github/renovate-default.json
@@ -64,6 +64,27 @@
       "matchDepTypes": ["dependencies"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "npm (minor and patch)"
+    },
+    {
+      "description": "Devkit-managed workflows and composite actions are regenerated wholesale on every devkit upgrade, so their SHA-pinned action digests are advanced upstream by devkit's own Renovate and shipped with each devkit release — never here. Disabling them stops duplicate/clobbering pin-bump PRs in consumer repos. This rule is intentionally last so a consumer's own later packageRules (in their preserved renovate.json) win: a consumer that wants to manage a specific managed file can re-enable it there. Refs vig-os/devkit#1332.",
+      "matchFileNames": [
+        ".github/workflows/ci.yml",
+        ".github/workflows/codeql.yml",
+        ".github/workflows/devkit-upgrade.yml",
+        ".github/workflows/prepare-release.yml",
+        ".github/workflows/promote-release.yml",
+        ".github/workflows/release-core.yml",
+        ".github/workflows/release-publish.yml",
+        ".github/workflows/release.yml",
+        ".github/workflows/renovate-changelog-build.yml",
+        ".github/workflows/renovate-changelog-commit.yml",
+        ".github/workflows/scorecard.yml",
+        ".github/workflows/sync-issues.yml",
+        ".github/workflows/sync-main-to-dev.yml",
+        ".github/actions/setup-devkit-toolchain/**",
+        ".github/actions/resolve-toolchain/**"
+      ],
+      "enabled": false
     }
   ]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,9 @@
 #   2. lint              — Pre-commit hooks
 #   3. test              — Run tests
 #   4. commit-checks     — Commit message + PR title validation (PRs only)
-#   5. dependency-review — Vulnerable-dependency gate (public-repo PRs only)
-#   6. summary           — Aggregate results for branch protection
+#   5. scaffold-drift    — Managed-file drift gate (PRs only; DEVKIT_DRIFT_CHECK)
+#   6. dependency-review — Vulnerable-dependency gate (public-repo PRs only)
+#   7. summary           — Aggregate results for branch protection
 #
 # Triggers:
 #   - Pull requests to dev, release/**, and main
@@ -80,6 +81,15 @@ jobs:
       image: ${{ steps.resolve.outputs.image }}
       image-tag: ${{ steps.resolve.outputs.image-tag }}
       runner-json: ${{ steps.resolve.outputs.runner-json }}
+      # Refs policy (#1282): re-export the composite action's mapped
+      # --refs-optional-types list so commit-checks can consume it via needs.
+      refs-optional-types: ${{ steps.resolve.outputs.refs-optional-types }}
+      # Scaffold-drift gate (#1295): re-export the DEVKIT_DRIFT_CHECK toggle so
+      # the scaffold-drift job's `if:` can self-skip when a consumer opts out,
+      # plus the all-modes image ref it `docker run`s (keeps the ghcr literal in
+      # resolve-toolchain, the #991 SSoT, out of this file).
+      drift-check: ${{ steps.resolve.outputs.drift-check }}
+      drift-image: ${{ steps.resolve.outputs.drift-image }}
 
     steps:
       - name: Checkout repository
@@ -219,6 +229,11 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
           BASE_REF: ${{ github.event.pull_request.base.ref }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          # Refs policy (#1282): the resolved --refs-optional-types list reaches
+          # the validator via env, never inline ${{ }} in the run block (the
+          # zizmor template-injection gate / #1279 env-routing pattern). Mapped
+          # once from DEVKIT_REFS_POLICY by resolve-toolchain.
+          REFS_OPTIONAL_TYPES: ${{ needs.resolve-toolchain.outputs.refs-optional-types }}
         run: |
           set -euo pipefail
           BASE_SHA="$(git merge-base "origin/${BASE_REF}" "${HEAD_SHA}")"
@@ -238,6 +253,7 @@ jobs:
             --base "${BASE_SHA}" \
             --head "${HEAD_SHA}" \
             --title "${PR_TITLE}" \
+            --refs-optional-types "${REFS_OPTIONAL_TYPES}" \
             --blocked-patterns .github/agent-blocklist.toml \
             ${EXCLUDE[@]+"${EXCLUDE[@]}"}
 
@@ -251,6 +267,90 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
         run: uv run check-pr-agent-fingerprints
+
+  # Scaffold-drift gate (#1295): re-run the pinned devkit version's scaffold over
+  # the checkout and fail if any managed file diverges — DEVKIT_VERSION bumped
+  # without re-scaffolding, or a managed file hand-edited. A pin-only bump PR
+  # otherwise merges green: nothing else re-runs the scaffold or diffs against it.
+  #
+  # Mechanism: re-scaffold + `git diff`, NOT `install.sh --preview`. The preview
+  # report classifies OVERWRITTEN by path existence, not content, so it fires for
+  # every managed file that exists and cannot distinguish drift from an
+  # up-to-date file. Re-running init-workspace.sh --force rewrites the managed
+  # files to exactly what the pin produces while preserving *.project files and
+  # persisted .vig-os values by construction; `git diff` (which honors .gitignore,
+  # so *.local files are exempt too) then surfaces any real divergence.
+  #
+  # This runs the in-image scaffold via `docker run` on the host runner rather
+  # than a job-level `container:`, because a direnv/bare consumer resolves an
+  # EMPTY image (its jobs run on the host) yet the scaffold assets live only
+  # inside the devcontainer image. Passing VIG_OS_VERSION=<current pin> keeps the
+  # .vig-os DEVKIT_VERSION line stable (the image's baked full version would
+  # otherwise rewrite a floating pin and read as spurious drift).
+  #
+  # Cost control: PRs only (the ~1.5 GiB image pull). A single workflow cannot
+  # apply a per-job `paths` filter, so the job rides the same pull_request-only
+  # gate as commit-checks/dependency-review; the DEVKIT_DRIFT_CHECK knob
+  # self-skips it at runtime (no re-scaffold needed to flip).
+  scaffold-drift:
+    name: Scaffold Drift
+    needs: [resolve-toolchain]
+    runs-on: ${{ fromJSON(needs.resolve-toolchain.outputs.runner-json) }}
+    timeout-minutes: 15
+    if: >-
+      github.event_name == 'pull_request' &&
+      needs.resolve-toolchain.outputs.drift-check != 'false'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      # All ${{ }} values reach the shell via env (never inline in run:), per the
+      # zizmor template-injection gate. The inner `docker run` script is a
+      # single-quoted literal — it reads only the -e env it is handed.
+      - name: Check for scaffold drift
+        env:
+          IMAGE: ${{ needs.resolve-toolchain.outputs.drift-image }}
+          IMAGE_TAG: ${{ needs.resolve-toolchain.outputs.image-tag }}
+          REGISTRY_TOKEN: ${{ secrets.GHCR_PULL_TOKEN || github.token }}
+          REGISTRY_USERNAME: ${{ github.actor }}
+          CONSUMER_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$IMAGE" ]]; then
+            echo "::error::Could not resolve DEVKIT_VERSION from .vig-os — cannot run the scaffold-drift check."
+            exit 1
+          fi
+
+          echo "Authenticating to ghcr.io as '${REGISTRY_USERNAME}'"
+          echo "$REGISTRY_TOKEN" | docker login ghcr.io -u "$REGISTRY_USERNAME" --password-stdin
+          echo "Pulling $IMAGE"
+          docker pull --quiet "$IMAGE"
+
+          # Re-scaffold in place inside the pinned image, then diff. The scaffold
+          # writes root-owned files into the mounted checkout, so run git in the
+          # same container (as root) with the mount marked a safe directory.
+          docker run --rm \
+            -e VIG_OS_VERSION="$IMAGE_TAG" \
+            -e GITHUB_REPOSITORY="$CONSUMER_REPOSITORY" \
+            -v "${GITHUB_WORKSPACE}:/workspace" \
+            "$IMAGE" \
+            bash -c '
+              set -euo pipefail
+              git config --global --add safe.directory /workspace
+              /root/assets/init-workspace.sh --force --no-prompts
+              cd /workspace
+              git add -A
+              if git diff --cached --quiet; then
+                echo "No scaffold drift detected — managed files match devkit ${VIG_OS_VERSION}."
+                exit 0
+              fi
+              echo "::error::Scaffold drift detected: the working tree diverges from what devkit ${VIG_OS_VERSION} would scaffold. Re-run the devkit upgrade (install.sh --force) and commit the result, or set DEVKIT_DRIFT_CHECK=false in .vig-os to opt out."
+              git --no-pager diff --cached
+              exit 1
+            '
 
   # Blocks PRs that introduce known-vulnerable dependencies, off GitHub's
   # dependency graph (lockfiles + action pins alike) — no toolchain, no
@@ -289,7 +389,7 @@ jobs:
     name: CI Summary
     runs-on: ${{ fromJSON(needs.resolve-toolchain.outputs.runner-json) }}
     timeout-minutes: 5
-    needs: [resolve-toolchain, lint, test, commit-checks, dependency-review]
+    needs: [resolve-toolchain, lint, test, commit-checks, scaffold-drift, dependency-review]
     if: always()
 
     steps:
@@ -302,6 +402,7 @@ jobs:
           echo "Lint: ${{ needs.lint.result }}"
           echo "Test: ${{ needs.test.result }}"
           echo "Commit messages: ${{ needs.commit-checks.result }}"
+          echo "Scaffold drift: ${{ needs.scaffold-drift.result }}"
           echo "Dependency review: ${{ needs.dependency-review.result }}"
           echo ""
 
@@ -324,6 +425,13 @@ jobs:
 
           if [ "${{ needs.commit-checks.result }}" = "failure" ]; then
             echo "ERROR: Commit message checks failed"
+            FAILED=true
+          fi
+
+          # Skipped on push/dispatch and when DEVKIT_DRIFT_CHECK=false; only a
+          # genuine failure (managed-file drift) trips the gate.
+          if [ "${{ needs.scaffold-drift.result }}" = "failure" ]; then
+            echo "ERROR: Scaffold drift detected"
             FAILED=true
           fi
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -80,11 +80,11 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v4
+        uses: github/codeql-action/init@d1ba80a13dd99fba24a470575428917156a28b43  # v4
         with:
           languages: ${{ matrix.language }}
 
       - name: Run CodeQL analysis
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v4
+        uses: github/codeql-action/analyze@d1ba80a13dd99fba24a470575428917156a28b43  # v4
         with:
           category: '/language:${{ matrix.language }}'

--- a/.github/workflows/devkit-upgrade.yml
+++ b/.github/workflows/devkit-upgrade.yml
@@ -1,0 +1,367 @@
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
+# Self-polling devkit upgrade (#1296). Weekly (and on explicit dispatch) this
+# checks for a newer devkit release and, when found, runs the full-fidelity
+# `install.sh --force` upgrade — the .vig-os pin, the flake.lock `vigos` node and
+# the full scaffold regeneration move together, with the commit made inside the
+# project shell so consumer hooks run — then opens the adoption PR. Renovate-style
+# pull: no devkit-side action at release time, no consumer registry.
+#
+# Requires a dedicated GitHub App identity: DEVKIT_UPGRADE_APP_ID +
+# DEVKIT_UPGRADE_APP_PRIVATE_KEY (repo or org secrets) feed a per-run
+# installation token minted in-workflow — contents:write + pull-requests:write +
+# issues:write + workflows:write on this repo. The default GITHUB_TOKEN cannot
+# open the PR: PRs it creates do not trigger CI. A static PAT is not supported
+# (#1302: user-bound, expiring, single-owner). The workflow fails fast when the
+# secrets are absent. App provisioning + rotation:
+# https://github.com/vig-os/devkit/issues/1302
+
+name: Devkit Upgrade
+
+on:  # yamllint disable-line rule:truthy
+  # Weekly, Monday early AM — aligned with the Renovate window (before 9am Mon).
+  # Scheduled runs execute from the default branch; the job checks out and
+  # targets the right base itself.
+  schedule:
+    - cron: '0 6 * * 1'
+  # Explicit version (final or rc) — the release-train / lane-re-bump path.
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Devkit version to adopt (final or rc, e.g. 1.5.0 or 1.5.0-rc1)'
+        required: true
+        type: string
+
+permissions: {}  # restrict default; the job declares its own
+
+concurrency:
+  group: devkit-upgrade-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  upgrade:
+    name: Adopt newer devkit
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      # The branch, issue and PR are all created with the minted App token (a
+      # dedicated identity, so the PR triggers CI); the default token stays
+      # read-only for the public releases/latest query.
+      contents: read
+    steps:
+      - name: Require the upgrade App identity
+        env:
+          APP_ID: ${{ secrets.DEVKIT_UPGRADE_APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.DEVKIT_UPGRADE_APP_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${APP_ID}" ] || [ -z "${APP_PRIVATE_KEY}" ]; then
+            echo "::error::DEVKIT_UPGRADE_APP_ID / DEVKIT_UPGRADE_APP_PRIVATE_KEY secrets are not configured. This workflow needs a dedicated GitHub App identity (contents:write + pull-requests:write + issues:write + workflows:write): the default GITHUB_TOKEN cannot open a PR that triggers CI, and a static PAT is not supported. See https://github.com/vig-os/devkit/issues/1302."
+            exit 1
+          fi
+
+      - name: Mint the upgrade App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3
+        with:
+          app-id: ${{ secrets.DEVKIT_UPGRADE_APP_ID }}
+          private-key: ${{ secrets.DEVKIT_UPGRADE_APP_PRIVATE_KEY }}
+          # Least-privilege mint (zizmor github-app): the token carries exactly
+          # the four permissions this workflow exercises, independent of any
+          # broader grants on the App installation.
+          permission-contents: write
+          permission-pull-requests: write
+          permission-issues: write
+          permission-workflows: write
+
+      - name: Checkout base branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          # Base branch per workflow model: gitflow -> dev, trunk -> main
+          # (retargeted to `main` at scaffold time for a trunk repo).
+          ref: dev
+          # Persist the minted token so the later push authenticates as the
+          # upgrade identity (whose PR triggers CI).
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Resolve target version
+        id: resolve
+        env:
+          # Route untrusted values through env (never inline ${{ }} in run:) —
+          # a dispatch input expanded as code is a template-injection sink.
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_VERSION: ${{ github.event.inputs.version }}
+          # Read-only public query — the default token is sufficient.
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          # Prerelease-aware semver compare: returns 0 (true) when $1 >= $2,
+          # treating a prerelease (X.Y.Z-rc1) as LOWER than its release (X.Y.Z).
+          # Load-bearing for the "current or ahead" no-op: a consumer on an rc of
+          # a newer train must never be downgraded to the older final.
+          version_ge() {
+            local a="$1" b="$2"
+            local acore="${a%%-*}" bcore="${b%%-*}"
+            local apre="" bpre=""
+            [ "$a" != "$acore" ] && apre="${a#*-}"
+            [ "$b" != "$bcore" ] && bpre="${b#*-}"
+            local i ai bi
+            local -a av bv
+            IFS='.' read -ra av <<< "$acore"
+            IFS='.' read -ra bv <<< "$bcore"
+            for i in 0 1 2; do
+              ai="${av[$i]:-0}"; bi="${bv[$i]:-0}"
+              if [ "$ai" -gt "$bi" ]; then return 0; fi
+              if [ "$ai" -lt "$bi" ]; then return 1; fi
+            done
+            # Equal cores: release > prerelease; prerelease compared lexically.
+            if [ -z "$apre" ] && [ -z "$bpre" ]; then return 0; fi
+            if [ -z "$apre" ]; then return 0; fi
+            if [ -z "$bpre" ]; then return 1; fi
+            [ "$apre" = "$bpre" ] && return 0
+            [ "$(printf '%s\n%s\n' "$apre" "$bpre" | LC_ALL=C sort | head -n1)" = "$bpre" ]
+          }
+
+          CURRENT="$(sed -n 's/^DEVKIT_VERSION=//p' .vig-os | head -n1)"
+          if [ -z "$CURRENT" ]; then
+            echo "::error::.vig-os has no DEVKIT_VERSION pin."
+            exit 1
+          fi
+
+          if [ "$EVENT_NAME" = "schedule" ]; then
+            # Opt-out knob: gates the schedule path only. Empty (default) or any
+            # value other than the literal `false` keeps auto-upgrade enabled.
+            AUTO="$(sed -n 's/^DEVKIT_AUTO_UPGRADE=//p' .vig-os | head -n1)"
+            if [ "$AUTO" = "false" ]; then
+              echo "DEVKIT_AUTO_UPGRADE=false — scheduled upgrade disabled; no-op."
+              echo "proceed=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            # releases/latest excludes prereleases and drafts by construction, so
+            # cron never proposes an rc.
+            TARGET="$(gh api repos/vig-os/devkit/releases/latest --jq .tag_name | sed 's/^v//')"
+          else
+            TARGET="${DISPATCH_VERSION#v}"
+          fi
+
+          # Validate the resolved version (defence-in-depth: TARGET flows into
+          # later shell / gh / git commands). A strict semver shape also rejects
+          # any hostile dispatch input before it can reach those sinks.
+          if ! printf '%s' "$TARGET" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+            echo "::error::Refusing to act on malformed target version: '${TARGET}'."
+            exit 1
+          fi
+
+          if [ "$EVENT_NAME" = "schedule" ] && version_ge "$CURRENT" "$TARGET"; then
+            echo "Current pin ${CURRENT} is at or ahead of latest ${TARGET}; no-op."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # The adoption issue + branch key on the TRAIN (prerelease stripped) so
+          # rc1 -> rc2 -> final within a train reuse the same issue/branch/PR; the
+          # commit + PR title carry the exact installed version.
+          TRAIN="${TARGET%%-*}"
+          {
+            echo "proceed=true"
+            echo "target=${TARGET}"
+            echo "train=${TRAIN}"
+            echo "branch-suffix=$(echo "${TRAIN}" | tr '.' '-')"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Find or create the adoption issue
+        id: issue
+        if: steps.resolve.outputs.proceed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TRAIN: ${{ steps.resolve.outputs.train }}
+        run: |
+          set -euo pipefail
+          TITLE="chore: adopt devkit ${TRAIN}"
+          NUMBER="$(gh issue list --state open --search "${TITLE} in:title" \
+            --json number,title \
+            --jq "map(select(.title == \"${TITLE}\")) | .[0].number // empty")"
+          if [ -z "$NUMBER" ]; then
+            URL="$(gh issue create --title "${TITLE}" \
+              --body "Automated adoption of devkit ${TRAIN}. Opened by the devkit-upgrade workflow (#1296).")"
+            NUMBER="${URL##*/}"
+            echo "Created adoption issue #${NUMBER}."
+          else
+            echo "Reusing open adoption issue #${NUMBER}."
+          fi
+          echo "number=${NUMBER}" >> "$GITHUB_OUTPUT"
+
+      - name: Create the upgrade branch
+        id: branch
+        if: steps.resolve.outputs.proceed == 'true'
+        env:
+          ISSUE: ${{ steps.issue.outputs.number }}
+          SUFFIX: ${{ steps.resolve.outputs.branch-suffix }}
+        run: |
+          set -euo pipefail
+          # Dots -> dashes: the consumer branch guard rejects dots and any
+          # prefix outside its allowlist (chore/ is allowed).
+          BRANCH="chore/${ISSUE}-devkit-${SUFFIX}"
+          git switch -c "$BRANCH" 2>/dev/null || git switch "$BRANCH"
+          echo "name=${BRANCH}" >> "$GITHUB_OUTPUT"
+
+      - name: Install Nix
+        if: steps.resolve.outputs.proceed == 'true'
+        uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342  # v31.11.0
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Run the devkit upgrade (install.sh --force)
+        if: steps.resolve.outputs.proceed == 'true'
+        env:
+          TARGET: ${{ steps.resolve.outputs.target }}
+        run: |
+          set -euo pipefail
+          # docker is present on ubuntu-latest (install.sh auto-detects it); nix
+          # (installed above) advances the floating `vigos` flake.lock node. The
+          # workflow owns the branch, so bypass install.sh's own preflight guard.
+          # --docker pins the runner's first-class runtime explicitly: the
+          # preinstalled podman can pair with a stale system crun that rejects
+          # podman >= 5's OCI configs (#1305) — auto-detection now prefers a
+          # responsive docker anyway, this makes the choice self-documenting.
+          curl -sSfL https://raw.githubusercontent.com/vig-os/devkit/main/install.sh \
+            | bash -s -- --force --version "$TARGET" --skip-preflight --docker .
+
+      - name: Reset excluded paths
+        if: steps.resolve.outputs.proceed == 'true'
+        run: |
+          set -euo pipefail
+          # DEVKIT_UPGRADE_EXCLUDE: comma-separated paths (whitespace-tolerant)
+          # reset to the base branch before the commit — e.g. generated-doc churn
+          # that must not ride along in the adoption diff.
+          EXCLUDE="$(sed -n 's/^DEVKIT_UPGRADE_EXCLUDE=//p' .vig-os | head -n1)"
+          IFS=',' read -ra PATHS <<< "$EXCLUDE"
+          for path in ${PATHS[@]+"${PATHS[@]}"}; do
+            path="$(echo "$path" | xargs)"
+            [ -z "$path" ] && continue
+            echo "Resetting excluded path: ${path}"
+            git checkout -- "$path" 2>/dev/null || true
+          done
+
+      - name: Commit the upgrade in the project shell
+        id: commit
+        if: steps.resolve.outputs.proceed == 'true'
+        env:
+          TARGET: ${{ steps.resolve.outputs.target }}
+          ISSUE: ${{ steps.issue.outputs.number }}
+          # Commit identity (configurable via repo variables). Must not match
+          # .github/agent-blocklist.toml — the default avoids github-actions[bot]
+          # and any AI-agent fingerprint.
+          GIT_AUTHOR_NAME: ${{ vars.DEVKIT_UPGRADE_AUTHOR_NAME || 'vigos-devkit-bot' }}
+          GIT_AUTHOR_EMAIL: ${{ vars.DEVKIT_UPGRADE_AUTHOR_EMAIL || 'devkit-bot@users.noreply.github.com' }}
+          GIT_COMMITTER_NAME: ${{ vars.DEVKIT_UPGRADE_AUTHOR_NAME || 'vigos-devkit-bot' }}
+          GIT_COMMITTER_EMAIL: ${{ vars.DEVKIT_UPGRADE_AUTHOR_EMAIL || 'devkit-bot@users.noreply.github.com' }}
+        run: |
+          set -euo pipefail
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No changes after upgrade; nothing to commit."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Commit INSIDE the project shell so consumer hooks run (dist rebuild in
+          # commit-action, trailer strip, validate-commit-msg). chore is
+          # Refs-exempt but include it for traceability. This LOCAL commit is a
+          # staging artifact only — the next step replays its tree through the
+          # API as a GitHub-signed commit; the unsigned one never leaves the
+          # runner (#1308).
+          printf 'chore: adopt devkit %s\n\nRefs: #%s\n' "$TARGET" "$ISSUE" > "${RUNNER_TEMP}/commit-msg"
+          nix develop -c git commit -F "${RUNNER_TEMP}/commit-msg"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Publish the adoption commit via API (verified)
+        if: steps.resolve.outputs.proceed == 'true' && steps.commit.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          BRANCH: ${{ steps.branch.outputs.name }}
+        run: |
+          set -euo pipefail
+          # The in-shell commit above is a STAGING artifact — hooks ran and the
+          # message validated, but a worktree commit is unsigned and consumers'
+          # Signed-commits rulesets rightfully reject it. Replay its tree
+          # through the git-data API with the App token instead: API-created
+          # commits are signed by GitHub as the App, so the published commit is
+          # verified and no ruleset needs a bypass (#1308). The tree API also
+          # carries an explicit mode per entry, so executable bits survive —
+          # createCommitOnBranch would silently drop them.
+          REPO="${GITHUB_REPOSITORY}"
+          MESSAGE="$(git log -1 --format=%B)"
+          BASE_SHA="$(git rev-parse HEAD^)"
+          BASE_TREE="$(gh api "repos/${REPO}/git/commits/${BASE_SHA}" --jq .tree.sha)"
+
+          # One tree entry per path the staging commit touched. --no-renames
+          # keeps the status alphabet to A/M/D (a rename becomes A + D).
+          entries='[]'
+          while IFS=$'\t' read -r status path; do
+            [ -n "$path" ] || continue
+            if [ "$status" = "D" ]; then
+              # Deletion: a null-sha entry removes the path from the tree.
+              entries="$(jq --arg p "$path" \
+                '. + [{path: $p, mode: "100644", type: "blob", sha: null}]' \
+                <<<"$entries")"
+            else
+              mode=100644
+              [ -x "$path" ] && mode=100755
+              blob="$(gh api -X POST "repos/${REPO}/git/blobs" \
+                -f content="$(base64 -w0 "$path")" -f encoding=base64 --jq .sha)"
+              entries="$(jq --arg p "$path" --arg m "$mode" --arg s "$blob" \
+                '. + [{path: $p, mode: $m, type: "blob", sha: $s}]' \
+                <<<"$entries")"
+            fi
+          done < <(git diff --name-status --no-renames "${BASE_SHA}" HEAD)
+
+          COUNT="$(jq length <<<"$entries")"
+          if [ "$COUNT" -eq 0 ]; then
+            echo "Empty delta after staging; nothing to publish."
+            exit 0
+          fi
+          echo "Publishing ${COUNT} tree entries..."
+
+          TREE="$(jq -n --argjson t "$entries" --arg b "$BASE_TREE" \
+            '{base_tree: $b, tree: $t}' \
+            | gh api -X POST "repos/${REPO}/git/trees" --input - --jq .sha)"
+          COMMIT="$(jq -n --arg m "$MESSAGE" --arg t "$TREE" --arg p "$BASE_SHA" \
+            '{message: $m, tree: $t, parents: [$p]}' \
+            | gh api -X POST "repos/${REPO}/git/commits" --input - --jq .sha)"
+
+          # Create the branch ref on first use; force-update within a train so
+          # rc -> rc -> final reuse refreshes the same branch/PR to the latest
+          # bump (the semantics the old force-push provided).
+          if gh api "repos/${REPO}/git/ref/heads/${BRANCH}" >/dev/null 2>&1; then
+            gh api -X PATCH "repos/${REPO}/git/refs/heads/${BRANCH}" \
+              -f sha="$COMMIT" -F force=true >/dev/null
+          else
+            gh api -X POST "repos/${REPO}/git/refs" \
+              -f ref="refs/heads/${BRANCH}" -f sha="$COMMIT" >/dev/null
+          fi
+          echo "Published verified commit ${COMMIT} to ${BRANCH}."
+
+      - name: Open or update the adoption PR
+        if: steps.resolve.outputs.proceed == 'true' && steps.commit.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TARGET: ${{ steps.resolve.outputs.target }}
+          ISSUE: ${{ steps.issue.outputs.number }}
+          BRANCH: ${{ steps.branch.outputs.name }}
+          # PR base per workflow model (retargeted dev -> main at scaffold time).
+          BASE: dev
+        run: |
+          set -euo pipefail
+          TITLE="chore: adopt devkit ${TARGET}"
+          BODY="$(printf 'Automated devkit upgrade to %s via install.sh --force.\n\nReview the scaffold + flake.lock diff and merge. Closes #%s\n' "$TARGET" "$ISSUE")"
+          if gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
+            gh pr edit "$BRANCH" --title "$TITLE" --body "$BODY"
+            echo "Updated the existing adoption PR."
+          else
+            gh pr create --base "$BASE" --head "$BRANCH" --title "$TITLE" --body "$BODY"
+            echo "Opened the adoption PR."
+          fi

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -178,7 +178,18 @@ jobs:
           # Compose the actual tag name (prefix + bare publish version) (#1044).
           PUBLISH_TAG="${TAG_PREFIX}${PUBLISH_VERSION}"
           git tag -a "$PUBLISH_TAG" -m "Release $PUBLISH_TAG"
-          if ! retry --retries 3 --backoff 5 --max-backoff 30 -- git push origin "$PUBLISH_TAG"; then
+          if ! PUSH_OUTPUT=$(retry --retries 3 --backoff 5 --max-backoff 30 -- git push origin "$PUBLISH_TAG" 2>&1); then
+            printf '%s\n' "$PUSH_OUTPUT"
+            # A tag name whose published release was deleted under release
+            # immutability is permanently retired; pushing it is rejected with
+            # GH013 and no retry or wait can ever succeed.
+            if printf '%s' "$PUSH_OUTPUT" | grep -Eqi "GH013|creations restricted"; then
+              echo "ERROR: Tag name $PUBLISH_TAG is tombstoned by release immutability:"
+              echo "a published GitHub Release for this tag was deleted, permanently retiring the name."
+              echo "This version is burned — re-cut the content as the next patch version."
+              echo "See https://github.com/vig-os/devkit/blob/main/docs/RELEASE_CYCLE.md ('Restarting a Finalized Release — the Point of No Return')."
+              exit 1
+            fi
             if retry --retries 3 --backoff 5 --max-backoff 30 -- git ls-remote --tags --refs origin "$PUBLISH_TAG" | grep -q "refs/tags/$PUBLISH_TAG$"; then
               LOCAL_TAG_TARGET_SHA=$(git rev-parse "$PUBLISH_TAG^{}")
               REMOTE_TAG_TARGET_SHA=$(retry --retries 3 --backoff 5 --max-backoff 30 -- git ls-remote --tags origin "refs/tags/$PUBLISH_TAG^{}" | awk '{print $1}')
@@ -243,19 +254,25 @@ jobs:
             echo "ERROR: Published (non-draft) GitHub Release already exists for tag $PUBLISH_TAG"
             exit 1
           fi
+          CREATE_ARGS=(--title "$PUBLISH_TAG" --notes-file /tmp/release-notes.md --verify-tag --draft)
           if [ "$RELEASE_KIND" = "candidate" ]; then
-            retry --retries 3 --backoff 5 --max-backoff 30 -- gh release create "$PUBLISH_TAG" \
-              --title "$PUBLISH_TAG" \
-              --notes-file /tmp/release-notes.md \
-              --verify-tag \
-              --draft \
-              --prerelease
-          else
-            retry --retries 3 --backoff 5 --max-backoff 30 -- gh release create "$PUBLISH_TAG" \
-              --title "$PUBLISH_TAG" \
-              --notes-file /tmp/release-notes.md \
-              --verify-tag \
-              --draft
+            CREATE_ARGS+=(--prerelease)
+          fi
+          if ! CREATE_OUTPUT=$(retry --retries 3 --backoff 5 --max-backoff 30 -- gh release create "$PUBLISH_TAG" "${CREATE_ARGS[@]}" 2>&1); then
+            printf '%s\n' "$CREATE_OUTPUT"
+            # A tag name whose published release was deleted under release
+            # immutability is retired forever: release creation for it fails
+            # with GH013 and no retry or wait can ever succeed.
+            if printf '%s' "$CREATE_OUTPUT" | grep -Eqi "GH013|creations restricted"; then
+              echo "ERROR: Tag name $PUBLISH_TAG is tombstoned by release immutability:"
+              echo "a published GitHub Release for this tag was deleted, permanently retiring the name."
+              echo "This version is burned — re-cut the content as the next patch version."
+              echo "See https://github.com/vig-os/devkit/blob/main/docs/RELEASE_CYCLE.md ('Restarting a Finalized Release — the Point of No Return')."
+            fi
+            exit 1
+          fi
+          printf '%s\n' "$CREATE_OUTPUT"
+          if [ "$RELEASE_KIND" = "final" ]; then
             echo "Draft GitHub Release created; publish from ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases when review is complete."
           fi
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -59,7 +59,7 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF to GitHub Security
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v4
+        uses: github/codeql-action/upload-sarif@d1ba80a13dd99fba24a470575428917156a28b43  # v4
         with:
           sarif_file: results.sarif
           category: 'scorecard'

--- a/.github/workflows/sync-issues.yml
+++ b/.github/workflows/sync-issues.yml
@@ -124,6 +124,14 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # This step runs `if: always()`, so it can fire after the job died
+          # before toolchain setup — before the `retry` shim exists. Without a
+          # fallback, `retry` in the CACHE_ID assignment below would emit
+          # "command not found" and `head` would still exit 0, silently masking
+          # the failure. Define a one-shot fallback (no retries) so a healthy
+          # run still uses the real shim and an early-failure run degrades
+          # gracefully. This cleanup is best-effort (continue-on-error).
+          command -v retry >/dev/null 2>&1 || retry() { while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do shift; done; shift; "$@"; }
           echo "Attempting to delete old cache to prevent save collisions..."
           # Wait a moment to ensure any previous cache saves have completed
           sleep 2

--- a/.vig-os
+++ b/.vig-os
@@ -7,7 +7,7 @@
 
 # Scaffold/image version pin (managed by release automation). Readers also
 # accept the legacy DEVCONTAINER_VERSION key for un-migrated consumers (#781).
-DEVKIT_VERSION=1.6.0-rc2
+DEVKIT_VERSION=1.6.0
 
 # Delivery mode: devcontainer | direnv | both | bare. Ships empty (= unset:
 # resolved and written back on scaffold) so an aborted upgrade can never

--- a/.vig-os
+++ b/.vig-os
@@ -7,7 +7,7 @@
 
 # Scaffold/image version pin (managed by release automation). Readers also
 # accept the legacy DEVCONTAINER_VERSION key for un-migrated consumers (#781).
-DEVKIT_VERSION=1.6.0-rc1
+DEVKIT_VERSION=1.6.0-rc2
 
 # Delivery mode: devcontainer | direnv | both | bare. Ships empty (= unset:
 # resolved and written back on scaffold) so an aborted upgrade can never

--- a/.vig-os
+++ b/.vig-os
@@ -7,7 +7,7 @@
 
 # Scaffold/image version pin (managed by release automation). Readers also
 # accept the legacy DEVCONTAINER_VERSION key for un-migrated consumers (#781).
-DEVKIT_VERSION=1.4.2
+DEVKIT_VERSION=1.6.0-rc1
 
 # Delivery mode: devcontainer | direnv | both | bare. Ships empty (= unset:
 # resolved and written back on scaffold) so an aborted upgrade can never
@@ -69,3 +69,51 @@ DEVKIT_SYNC_TARGET=
 # the sync weekly on Sundays. Realized at scaffold time because schedule triggers
 # cannot take inputs (#1228).
 DEVKIT_SYNC_SCHEDULE=
+
+# Scaffold feature groups this repo opts OUT of — a comma-separated,
+# whitespace-tolerant subset of: release, renovate, sync-issues, scanning,
+# gh-templates, skills, worktree, devkit-upgrade. Empty (default) => every group is scaffolded
+# (no change for existing consumers). A disabled group is never shipped, and a
+# copy left by a prior scaffold is pruned on upgrade; clearing the key re-ships
+# it on the next `--force`. Consumer-owned extension seams
+# (release-extension.yml, prepare-release-extension.yml) and renovate.json are
+# left in place if present (never pruned). Governs scaffold SHAPE only, not the
+# flake — an unknown name aborts the scaffold loudly (#1284).
+DEVKIT_FEATURES_DISABLED=
+
+# Refs-line enforcement policy for the commit-message gate, driving BOTH the
+# validate-commit-msg pre-commit hook and CI's validate-commit-range from this
+# one key. Empty (default) resolves to `chore-optional` — every type but `chore`
+# requires a `Refs:` line — unchanged for devkit or existing consumers.
+# `optional` never requires Refs (any approved type may omit it); `required`
+# demands Refs on every type, `chore` included. Realized at scaffold time (an
+# anchored render of the hook arg + resolve-toolchain's `refs-optional-types`
+# output); written back only for a non-default value (#1282).
+DEVKIT_REFS_POLICY=
+
+# Auto-upgrade opt-out for the scaffolded devkit-upgrade.yml workflow. Empty
+# (default) or any value other than `false` keeps the WEEKLY schedule path
+# enabled — it polls devkit's latest release and, when this repo's DEVKIT_VERSION
+# is behind, opens the adoption PR. `false` disables ONLY the schedule; manual
+# `workflow_dispatch` (the release-train / rc re-bump path) always runs. A
+# runtime gate read from this file — no re-scaffold to flip. Written back only
+# for a non-default (`false`) value, so a default .vig-os is unchanged (#1296).
+DEVKIT_AUTO_UPGRADE=
+
+# Paths the devkit-upgrade workflow resets (git checkout --) after the scaffold
+# regeneration but before the adoption commit, so they never ride along in the
+# upgrade diff — e.g. a consumer's generated-doc churn. Comma-separated,
+# whitespace-tolerant (like DEVKIT_FEATURES_DISABLED). Empty (default) => no
+# exclusions. A runtime gate read from this file; written back only for a
+# non-empty value (#1296).
+DEVKIT_UPGRADE_EXCLUDE=
+
+# Scaffold-drift CI gate: true (default) | false. Empty (= unset) resolves to
+# `true` — ci.yml's `scaffold-drift` job re-runs the pinned devkit version's
+# scaffold over the checkout and fails a PR whose managed files diverge from it
+# (DEVKIT_VERSION bumped without re-scaffold, or a managed file hand-edited).
+# `*.project` files and persisted values in this manifest are exempt by
+# construction (the scaffold never overwrites them). Pure runtime gate — CI reads
+# it via resolve-toolchain's `drift-check` output, so flipping it takes effect
+# with no re-scaffold; the value round-trips across `--force` upgrades (#1295).
+DEVKIT_DRIFT_CHECK=

--- a/flake.lock
+++ b/flake.lock
@@ -103,11 +103,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1782116945,
-        "narHash": "sha256-G3tw/IXmaH6IQ2upZvhuN9sG8CkuX+BLuJDpE8hz0Ds=",
+        "lastModified": 1785104993,
+        "narHash": "sha256-eKbrvPoAOFutbYMdbB3r5EQVmFxKv24iKqHPPUXA0gM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "34268251cf5547d39063f2c5ea9a196246f7f3a6",
+        "rev": "8623c4c20aa4ca2f5fb81510d2944066c3fb0d96",
         "type": "github"
       },
       "original": {
@@ -119,11 +119,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1784453100,
-        "narHash": "sha256-zpGZb8FYui+i8KLtC0nlcmb0voR2zB80Qn8pe7lzIbk=",
+        "lastModified": 1785110946,
+        "narHash": "sha256-WWuWxmXKzGZWryswWlijP3Mjp6aGy4Ngmeil5nGMMjk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b471514bed69eff5255c8e63c1f80e5fe56c616f",
+        "rev": "d3498f786f97ac0bded21b34bae0bf3809b45aa3",
         "type": "github"
       },
       "original": {
@@ -224,11 +224,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1785079284,
-        "narHash": "sha256-22xlYj2gwUq1Cz8Ivz9H3Vs+nPYutevzQp5mLW6u31U=",
+        "lastModified": 1785448519,
+        "narHash": "sha256-vWWdxD/hq1oSI6WPsCEkP5o11Y4an+msfFAimhXhxnQ=",
         "owner": "vig-os",
         "repo": "devkit",
-        "rev": "b884b22bcb0b3ad1d192c1b5b4b4251c90202c23",
+        "rev": "26e291dfb5e67dd4228c95d4adfa8791b5440140",
         "type": "github"
       },
       "original": {

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -35,7 +35,8 @@
 # Residual (baselined below), why each is intentional:
 #   - artipacked        → checkouts that push or fetch from a private remote and
 #                         therefore rely on the persisted git credential
-#                         (ci.yml commit-checks, all release/sync branch work).
+#                         (ci.yml commit-checks, all release/sync branch work,
+#                         devkit-upgrade's self-upgrade branch push).
 #   - dangerous-triggers → renovate-changelog-commit.yml runs on `workflow_run`
 #                         by design (it commits the built changelog).
 #   - github-app        → create-github-app-token intentionally mints a
@@ -51,6 +52,7 @@ rules:
   artipacked:
     ignore:
       - ci.yml
+      - devkit-upgrade.yml
       - prepare-release.yml
       - promote-release.yml
       - release-core.yml


### PR DESCRIPTION
Validates the devkit 1.6.0-rc1 candidate on this gitflow consumer (release-train lane).

- `DEVKIT_VERSION` 1.4.2 → 1.6.0-rc1; managed scaffold refreshed
- New: `devkit-upgrade.yml` self-polling workflow (#1296), scaffold-drift CI gate (#1295), Refs-policy + feature-group manifest keys (#1282, #1284)
- Renovate preset now excludes devkit-managed workflows/actions (vig-os/devkit#1332) — supersedes open Renovate PRs on managed files
- `release-publish.yml` tombstone (GH013) detection (vig-os/devkit#1319)
- Floating `vigos` flake input advanced (main @ 1.5.1)

Part of the vig-os/devkit 1.6.0 release train (milestone 15). Bump to 1.6.0 final before merge at promote time.