### PR TITLE
chore: advance vigos flake pin to devkit 1.6.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -103,11 +103,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1785104993,
-        "narHash": "sha256-eKbrvPoAOFutbYMdbB3r5EQVmFxKv24iKqHPPUXA0gM=",
+        "lastModified": 1785734586,
+        "narHash": "sha256-ODZkEK9Gy50yg6h98u7KkitZ3oc/uuTFK00bh1CRdNA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8623c4c20aa4ca2f5fb81510d2944066c3fb0d96",
+        "rev": "531670d871c0e29724a02f3cbcac170adc65b58c",
         "type": "github"
       },
       "original": {
@@ -119,11 +119,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1785110946,
-        "narHash": "sha256-WWuWxmXKzGZWryswWlijP3Mjp6aGy4Ngmeil5nGMMjk=",
+        "lastModified": 1785602060,
+        "narHash": "sha256-z7D96eESRM4CPV/XtwpwFn8IDdfLAmxz6lVWrGYXvR4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d3498f786f97ac0bded21b34bae0bf3809b45aa3",
+        "rev": "a5cbcfe954791221bfffe2307f7d1a1bf61a871e",
         "type": "github"
       },
       "original": {
@@ -224,11 +224,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1785448519,
-        "narHash": "sha256-vWWdxD/hq1oSI6WPsCEkP5o11Y4an+msfFAimhXhxnQ=",
+        "lastModified": 1785849993,
+        "narHash": "sha256-q/gD03js0TBxpra5QyBZjHWVOlJbhRX6qvnObAP5tGI=",
         "owner": "vig-os",
         "repo": "devkit",
-        "rev": "26e291dfb5e67dd4228c95d4adfa8791b5440140",
+        "rev": "ffa7a5faedab86f18d7443806cc4ea58073ce1bd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
The 1.6.0 adoption (#160) bumped `.vig-os` to 1.6.0 final as a pin-only edit, leaving the floating `vigos` flake input locked at `26e291d` (the 1.5.1 release) — so the dev shell ran the 1.5.1 toolchain under the 1.6.0 scaffold and the shell-entry version-skew warning (vig-os/devkit#1263) fired on every entry.

This advances the lock to `ffa7a5f` (the 1.6.0 release commit) via `nix flake update vigos`. Verified: 1.6.0 shell builds, full prek suite green.

Follow-up to #160.
