### PR TITLE
feat: add client-id input as preferred App credential

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`client-id` input as the preferred GitHub App credential** ([#168](https://github.com/vig-os/sync-issues-action/issues/168))
+  - Forwarded to `createAppAuth` exactly as `app-id` is; setting both inputs fails with an explicit error
+
 ### Changed
 
 ### Deprecated
+
+- **`app-id` input** ([#168](https://github.com/vig-os/sync-issues-action/issues/168))
+  - Still works unchanged, but emits a runtime deprecation warning; use `client-id` instead
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -38,15 +38,16 @@ A GitHub Action that syncs all issues and pull requests from a repository to mar
   uses: vig-os/sync-issues-action@abc123def456
 ```
 
-**Note:** `${{ github.token }}` is provided automatically by GitHub Actions and is used by default. You can override it by passing your own `token` input if needed or using GitHub App authentication.
+**Note:** `${{ github.token }}` is provided automatically by GitHub Actions and is used by default. You can override it by passing your own `token` input if needed or using GitHub App authentication (`client-id` + `app-private-key`).
 
 ### Options
 
 | Input | Description | Required | Default |
 |-------|-------------|----------|---------|
 | `token` | GitHub token with repo access. | No | `${{ github.token }}` |
-| `app-id` | GitHub App ID. If provided with `app-private-key`, will use app authentication. | No | - |
-| `app-private-key` | GitHub App private key. If provided with `app-id`, will use app authentication. | No | - |
+| `client-id` | GitHub App Client ID (preferred). If provided with `app-private-key`, will use app authentication. | No | - |
+| `app-id` | GitHub App ID. **Deprecated:** use `client-id` instead. Do not set both. | No | - |
+| `app-private-key` | GitHub App private key. If provided with `client-id` (or `app-id`), will use app authentication. | No | - |
 | `output-dir` | Directory to store markdown files | No | `synced-issues` |
 | `sync-issues` | Whether to sync issues | No | `true` |
 | `sync-prs` | Whether to sync pull requests | No | `true` |

--- a/action.yml
+++ b/action.yml
@@ -25,8 +25,11 @@ inputs:
     description: 'Whether to include closed issues/PRs'
     required: false
     default: 'false'
+  client-id:
+    description: 'GitHub App Client ID (optional, preferred App credential)'
+    required: false
   app-id:
-    description: 'GitHub App ID (optional)'
+    description: 'GitHub App ID (optional, deprecated: use client-id instead)'
     required: false
   app-private-key:
     description: 'GitHub App private key (PEM, optional)'

--- a/dist/index.js
+++ b/dist/index.js
@@ -39649,14 +39649,23 @@ async function run() {
         if (!githubToken) {
             throw new Error('GitHub token is required. Provide it via the action input "token" or ensure GITHUB_TOKEN is available.');
         }
-        // Check if GitHub App credentials are provided
-        const appId = getInput('app-id') || '';
+        // Check if GitHub App credentials are provided (client-id preferred, app-id deprecated)
+        const clientId = getInput('client-id') || '';
+        const legacyAppId = getInput('app-id') || '';
+        if (clientId && legacyAppId) {
+            throw new Error('Both client-id and app-id were provided. Set only client-id (app-id is deprecated).');
+        }
+        if (legacyAppId) {
+            warning('The app-id input is deprecated. Use client-id instead.');
+        }
+        const appId = clientId || legacyAppId;
         const appPrivateKey = getInput('app-private-key') || '';
         let appToken;
         let tokenToUse = githubToken;
         // Validate app credentials: both must be provided together, or neither
         if ((appId && !appPrivateKey) || (!appId && appPrivateKey)) {
-            throw new Error('GitHub App authentication requires both app-id and app-private-key. Provide both or neither.');
+            const credInputName = legacyAppId ? 'app-id' : 'client-id';
+            throw new Error(`GitHub App authentication requires both ${credInputName} and app-private-key. Provide both or neither.`);
         }
         if (appId && appPrivateKey) {
             info('GitHub App credentials provided. Generating installation token...');

--- a/example-workflow.yml
+++ b/example-workflow.yml
@@ -64,7 +64,7 @@ jobs:
         # If using locally from the same repository, use: ./
         with:
           # Optional: Use GitHub App authentication to bypass rulesets
-          # app-id: ${{ secrets.APP_SYNC_ISSUES_ID }}
+          # client-id: ${{ secrets.APP_SYNC_ISSUES_CLIENT_ID }}
           # app-private-key: ${{ secrets.APP_SYNC_ISSUES_PRIVATE_KEY }}
           output-dir: 'synced-issues'
           sync-issues: 'true'

--- a/src/__tests__/unit/index.test.ts
+++ b/src/__tests__/unit/index.test.ts
@@ -2,6 +2,7 @@
 // Mocks are set up in setup.ts which runs before this file
 import * as core from '@actions/core';
 import * as github from '@actions/github';
+import { createAppAuth } from '@octokit/auth-app';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as childProcess from 'child_process';
@@ -2446,7 +2447,7 @@ describe('Sync Issues Action', () => {
 
         expect(mockSetFailed).toHaveBeenCalledWith(
           expect.stringContaining(
-            'GitHub App authentication requires both app-id and app-private-key'
+            'GitHub App authentication requires both client-id and app-private-key'
           )
         );
       });
@@ -2510,6 +2511,110 @@ describe('Sync Issues Action', () => {
 
         expect(mockSetOutput).toHaveBeenCalledWith('app-token', 'mock-installation-token');
         expect(mockSetOutput).toHaveBeenCalledWith('github-token', 'test-token');
+      });
+
+      it('should generate app token when client-id and app-private-key provided', async () => {
+        mockGetInput.mockImplementation((name: string): string => {
+          if (name === 'token') return 'test-token';
+          if (name === 'client-id') return 'Iv23liMockClientId';
+          if (name === 'app-private-key') return 'MOCK_PRIVATE_KEY_FOR_TESTING_ONLY';
+          return '';
+        });
+
+        const mockOctokit = {
+          rest: {
+            issues: {
+              listForRepo: jest.fn().mockResolvedValue({ data: [] }),
+              get: jest.fn(),
+              listComments: jest.fn().mockResolvedValue({ data: [] }),
+            },
+            pulls: {
+              list: jest.fn().mockResolvedValue({ data: [] }),
+              get: jest.fn(),
+              listReviewComments: jest.fn().mockResolvedValue({ data: [] }),
+            },
+            apps: {
+              getRepoInstallation: jest.fn().mockResolvedValue({ data: { id: 67890 } }),
+            },
+          },
+        };
+        setMockOctokit(mockOctokit);
+
+        await run();
+
+        expect(createAppAuth).toHaveBeenCalledWith({
+          appId: 'Iv23liMockClientId',
+          privateKey: 'MOCK_PRIVATE_KEY_FOR_TESTING_ONLY',
+        });
+        expect(mockSetOutput).toHaveBeenCalledWith('app-token', 'mock-installation-token');
+        expect(mockWarning).not.toHaveBeenCalledWith(expect.stringContaining('deprecated'));
+      });
+
+      it('should warn that app-id is deprecated when used', async () => {
+        mockGetInput.mockImplementation((name: string): string => {
+          if (name === 'token') return 'test-token';
+          if (name === 'app-id') return '12345';
+          if (name === 'app-private-key') return 'MOCK_PRIVATE_KEY_FOR_TESTING_ONLY';
+          return '';
+        });
+
+        const mockOctokit = {
+          rest: {
+            issues: {
+              listForRepo: jest.fn().mockResolvedValue({ data: [] }),
+              get: jest.fn(),
+              listComments: jest.fn().mockResolvedValue({ data: [] }),
+            },
+            pulls: {
+              list: jest.fn().mockResolvedValue({ data: [] }),
+              get: jest.fn(),
+              listReviewComments: jest.fn().mockResolvedValue({ data: [] }),
+            },
+            apps: {
+              getRepoInstallation: jest.fn().mockResolvedValue({ data: { id: 67890 } }),
+            },
+          },
+        };
+        setMockOctokit(mockOctokit);
+
+        await run();
+
+        expect(mockWarning).toHaveBeenCalledWith(
+          expect.stringContaining('app-id input is deprecated')
+        );
+        expect(mockSetOutput).toHaveBeenCalledWith('app-token', 'mock-installation-token');
+      });
+
+      it('should throw error when both client-id and app-id provided', async () => {
+        mockGetInput.mockImplementation((name: string): string => {
+          if (name === 'token') return 'test-token';
+          if (name === 'client-id') return 'Iv23liMockClientId';
+          if (name === 'app-id') return '12345';
+          if (name === 'app-private-key') return 'MOCK_PRIVATE_KEY_FOR_TESTING_ONLY';
+          return '';
+        });
+
+        await run();
+
+        expect(mockSetFailed).toHaveBeenCalledWith(
+          expect.stringContaining('Both client-id and app-id were provided')
+        );
+      });
+
+      it('should throw error when only client-id provided', async () => {
+        mockGetInput.mockImplementation((name: string): string => {
+          if (name === 'token') return 'test-token';
+          if (name === 'client-id') return 'Iv23liMockClientId';
+          return '';
+        });
+
+        await run();
+
+        expect(mockSetFailed).toHaveBeenCalledWith(
+          expect.stringContaining(
+            'GitHub App authentication requires both client-id and app-private-key'
+          )
+        );
       });
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -401,16 +401,27 @@ async function run(): Promise<void> {
       );
     }
 
-    // Check if GitHub App credentials are provided
-    const appId = core.getInput('app-id') || '';
+    // Check if GitHub App credentials are provided (client-id preferred, app-id deprecated)
+    const clientId = core.getInput('client-id') || '';
+    const legacyAppId = core.getInput('app-id') || '';
+    if (clientId && legacyAppId) {
+      throw new Error(
+        'Both client-id and app-id were provided. Set only client-id (app-id is deprecated).'
+      );
+    }
+    if (legacyAppId) {
+      core.warning('The app-id input is deprecated. Use client-id instead.');
+    }
+    const appId = clientId || legacyAppId;
     const appPrivateKey = core.getInput('app-private-key') || '';
     let appToken: string | undefined;
     let tokenToUse: string = githubToken;
 
     // Validate app credentials: both must be provided together, or neither
     if ((appId && !appPrivateKey) || (!appId && appPrivateKey)) {
+      const credInputName = legacyAppId ? 'app-id' : 'client-id';
       throw new Error(
-        'GitHub App authentication requires both app-id and app-private-key. Provide both or neither.'
+        `GitHub App authentication requires both ${credInputName} and app-private-key. Provide both or neither.`
       );
     }
 


### PR DESCRIPTION
Closes #168

## What

- Add a `client-id` input to `action.yml` as the preferred GitHub App credential, aliased onto the same code path as `app-id` (the value is forwarded verbatim to `createAppAuth`, which accepts client IDs).
- Keep `app-id` working unchanged for back-compat, with a deprecation note in its description and a `core.warning` at runtime.
- Setting both inputs fails with an explicit error instead of silently picking one.
- Credential pair-validation errors now name whichever input the caller used.
- README, `example-workflow.yml`, and changelog updated; `dist/` rebuilt.

## Tests

New unit cases cover: `client-id` + key (token generated, `createAppAuth` receives the client ID, no deprecation warning), `app-id` + key (still works, warns deprecated), both set (explicit failure), `client-id` alone (pair-validation error naming `client-id`). Existing cases untouched except the only-private-key error string, which now names `client-id`.

## Follow-up

Minor release 0.5.0 (rebuilt `dist/`) after merge; tag + SHA to be recorded on #168 for the pinned downstream consumers (vig-os/devkit#1365, vig-os/tessera#364, …).