### PR TITLE
chore: merge dev into release/0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Renovate: update `tsx` from `4.23.7` to `4.23.11`** ([#169](https://github.com/vig-os/sync-issues-action/pull/169))
+
 ### Deprecated
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Renovate: update `tsx` from `4.23.7` to `4.23.11`** ([#169](https://github.com/vig-os/sync-issues-action/pull/169))
-
 ### Deprecated
 
 ### Removed
@@ -27,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`client-id` input as the preferred GitHub App credential** ([#168](https://github.com/vig-os/sync-issues-action/issues/168))
   - Forwarded to `createAppAuth` exactly as `app-id` is; setting both inputs fails with an explicit error
+
+### Changed
+
+- **Renovate: update `tsx` from `4.23.7` to `4.23.11`** ([#169](https://github.com/vig-os/sync-issues-action/pull/169))
 
 ### Deprecated
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6158,9 +6158,9 @@
       "optional": true
     },
     "node_modules/tsx": {
-      "version": "4.23.7",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.7.tgz",
-      "integrity": "sha512-3f/u/+UDCNQ7iwUZW9FCMnNGIHzElGJYh0S/yy8IvWSsn5O7fEO/897FaG7FA2W8yryiRyuwXZ1PYLAKYaqSuQ==",
+      "version": "4.23.11",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.11.tgz",
+      "integrity": "sha512-Ry2oTEUnhBdeEdWIztY8kf3/nBGnPnjMLVGL0YfdRXMORuPER5NlKmayqxtxRxwB1xBN+RivRaJfe7PM1rtiyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3166,9 +3166,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001806",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
-      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
+      "version": "1.0.30001809",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+      "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
       "dev": true,
       "funding": [
         {
@@ -3462,9 +3462,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.401",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.401.tgz",
-      "integrity": "sha512-H6ViHN68nGYlChEvlIU67fn8O2/tpbWQPwck98yaJmh+08LSvHiydzDQ6oXNccLU3kNRVIRS9A4mA7CG+i6fLQ==",
+      "version": "1.5.402",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.402.tgz",
+      "integrity": "sha512-/oOpMaPT6Yg+6/1XQhyIPlzgj7Ye9zf+nNM2Uh6OcE2G2oNptWazFa+qB2Pdqqbsc9KnIDzgAntoYN0dbwOXwA==",
       "dev": true,
       "license": "ISC"
     },
@@ -5228,9 +5228,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.52",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.52.tgz",
-      "integrity": "sha512-MRlTqhAfoMx/4mhEbPo3Hi02g9LJZaJkka69V6h67Cb1gjrAG0jsTE4CZX1eptNx+VCAwJmfpnDIF4P0Nh1A7A==",
+      "version": "2.0.53",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+      "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6158,9 +6158,9 @@
       "optional": true
     },
     "node_modules/tsx": {
-      "version": "4.23.7",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.7.tgz",
-      "integrity": "sha512-3f/u/+UDCNQ7iwUZW9FCMnNGIHzElGJYh0S/yy8IvWSsn5O7fEO/897FaG7FA2W8yryiRyuwXZ1PYLAKYaqSuQ==",
+      "version": "4.23.11",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.11.tgz",
+      "integrity": "sha512-Ry2oTEUnhBdeEdWIztY8kf3/nBGnPnjMLVGL0YfdRXMORuPER5NlKmayqxtxRxwB1xBN+RivRaJfe7PM1rtiyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6340,9 +6340,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.0.tgz",
+      "integrity": "sha512-x/M6q3w4Ybp91CNaS4S69UnliqR3BzRpOT6LWbksjth0S/+jhfaPJsWjt/TewpT8j9eLIojUf5jr29WextHroA==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Fold the two Renovate updates that landed on `dev` after the freeze into the 0.5.0 release:

- tsx `4.23.7` → `4.23.11` (#169)
- lock file maintenance (#170)

Both are dev-tooling-only lockfile changes (`package.json` untouched, no runtime deps moved), so `dist/` is unaffected — verified locally with `just verify-dist` (clean) and 142/142 unit tests. The #169 changelog entry is moved from `Unreleased` into the frozen `[0.5.0] - TBD` section.

Refs: #168